### PR TITLE
We now check if "break" and "continue" are outside of a loop or not.

### DIFF
--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -18,7 +18,7 @@ jobs:
       with:
         fetch-depth: 2
 
-    - name: Check formatting.
+    - name: Print clang-format version.
       id: clang-format-version
       run: |
         echo "Clang-format version:"

--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -19,6 +19,12 @@ jobs:
         fetch-depth: 2
 
     - name: Check formatting.
+      id: clang-format-version
+      run: |
+        echo "Clang-format version:"
+        clang-format --version
+
+    - name: Check formatting.
       id: check-format
       run: |
         STATUS=0

--- a/cmake/clang-tidy.cmake
+++ b/cmake/clang-tidy.cmake
@@ -10,8 +10,8 @@ find_program(
 set(
 	CLANG_TIDY_COMMAND
 	${CLANG_TIDY_PATH};
-	-header-filter=src/.*;
-	-extra-arg=-std=c++2b;
+	--header-filter=src/.*;
+	--extra-arg=-std=c++2b;
 )
 
 set_target_properties(

--- a/samples/loop.cw
+++ b/samples/loop.cw
@@ -10,6 +10,7 @@ fn main() -> int {
 
    #loop {
      #break
+     continue
    #}
 
    return sum

--- a/src/crow/ast/archive/archive.hpp
+++ b/src/crow/ast/archive/archive.hpp
@@ -36,7 +36,7 @@
 //!
 #define AST_ARCHIVE_DEFINE_SERIALIZE_METHOD() \
   template<typename Archive>                  \
-  auto serialize([[maybe_unused]] Archive& t_archive)->void
+  auto serialize([[maybe_unused]] Archive& t_archive) -> void
 
 //!
 #define AST_ARCHIVE_DEFINE_SERIALIZE_METHOD_NIL() \

--- a/src/crow/ast/node/node_traits/node_position.hpp
+++ b/src/crow/ast/node/node_traits/node_position.hpp
@@ -3,8 +3,8 @@
 
 
 // Includes:
-#include "crow/container/text_position.hpp"
 #include "../include.hpp"
+#include "crow/container/text_position.hpp"
 
 // Local Includes:
 #include "fdecl.hpp"

--- a/src/crow/ast/node/node_traits/typing/native_types.cpp
+++ b/src/crow/ast/node/node_traits/typing/native_types.cpp
@@ -108,8 +108,8 @@ auto nativetype2str(const NativeType t_native_type) -> std::string
 }
 } // namespace ast::node::node_traits::typing
 
-auto operator<<(std::ostream& t_os, const NativeType t_native_type)
-  -> std::ostream&
+auto operator<<(std::ostream& t_os,
+                const NativeType t_native_type) -> std::ostream&
 {
   t_os << nativetype2str(t_native_type);
 

--- a/src/crow/ast/node/operators/unary_prefix.hpp
+++ b/src/crow/ast/node/operators/unary_prefix.hpp
@@ -24,9 +24,9 @@ enum class UnaryPrefixOp {
 // Classes:
 class UnaryPrefix : public Op<UnaryPrefixOp>, public UnaryOperator {
   public:
-	/*!
-	 * Constructor will throw if given inconvertible @ref TokenType.
-	 */
+  /*!
+   * Constructor will throw if given inconvertible @ref TokenType.
+   */
   UnaryPrefix(token::TokenType t_op, NodePtr&& t_left);
   UnaryPrefix(UnaryPrefixOp t_op, NodePtr&& t_left);
 

--- a/src/crow/ast/visitor/ast_archive.cpp
+++ b/src/crow/ast/visitor/ast_archive.cpp
@@ -10,12 +10,12 @@
  *
  * @param[in] t_type Type of Node to accept.
  */
-#define DEFINE_SERIALIZE_METHOD(t_type)                       \
-  auto AstArchive::visit([[maybe_unused]] t_type* t_ptr)->Any \
-  {                                                           \
-    archive(*t_ptr);                                          \
-                                                              \
-    return {};                                                \
+#define DEFINE_SERIALIZE_METHOD(t_type)                         \
+  auto AstArchive::visit([[maybe_unused]] t_type* t_ptr) -> Any \
+  {                                                             \
+    archive(*t_ptr);                                            \
+                                                                \
+    return {};                                                  \
   }
 
 namespace ast::visitor {
@@ -24,8 +24,8 @@ NODE_USING_ALL_NAMESPACES()
 
 // Methods:
 // Protected Methods:
-auto AstArchive::set_archive_out(const ArchiveType t_type, std::ostream& t_os)
-  -> void
+auto AstArchive::set_archive_out(const ArchiveType t_type,
+                                 std::ostream& t_os) -> void
 {
   using exception::error;
 
@@ -52,8 +52,8 @@ auto AstArchive::set_archive_out(const ArchiveType t_type, std::ostream& t_os)
   }
 }
 
-auto AstArchive::set_archive_in(const ArchiveType t_type, std::istream& t_is)
-  -> void
+auto AstArchive::set_archive_in(const ArchiveType t_type,
+                                std::istream& t_is) -> void
 {
   using exception::error;
 

--- a/src/crow/ast/visitor/ast_archive.hpp
+++ b/src/crow/ast/visitor/ast_archive.hpp
@@ -75,7 +75,8 @@ class AstArchive : public NodeVisitor {
       t_archive(std::forward<Args>(t_args)...);
     }};
 
-    const auto fn_monostate{[]([[maybe_unused]] std::monostate t_state) {
+    const auto fn_monostate{[]([[maybe_unused]]
+                               std::monostate t_state) {
       error("Attempted to archive std::monostate.");
     }};
 

--- a/src/crow/ast/visitor/ast_archive.hpp
+++ b/src/crow/ast/visitor/ast_archive.hpp
@@ -59,13 +59,13 @@ class AstArchive : public NodeVisitor {
   auto set_archive_out(ArchiveType t_type, std::ostream& t_os) -> void;
   auto set_archive_in(ArchiveType t_type, std::istream& t_is) -> void;
 
-	/*!
-	 * Helper method for archiving AST nodes.
-	 * Throws if @ref m_archive is std::monostate.
-	 *
-	 * @param[in] t_args Variadic argument of AST nodes to archive.
-	 *
-	 */
+  /*!
+   * Helper method for archiving AST nodes.
+   * Throws if @ref m_archive is std::monostate.
+   *
+   * @param[in] t_args Variadic argument of AST nodes to archive.
+   *
+   */
   template<typename... Args>
   auto archive(Args&&... t_args) -> void
   {

--- a/src/crow/ast/visitor/ast_printer.cpp
+++ b/src/crow/ast/visitor/ast_printer.cpp
@@ -22,15 +22,15 @@
  *
  * @param[in] t_type Type of Node to accept.
  */
-#define DEFINE_PRINTER_METHOD(t_type)                         \
-  auto AstPrinter::visit([[maybe_unused]] t_type* t_ptr)->Any \
-  {                                                           \
-    COUNTG_INIT();                                            \
-                                                              \
-    print(#t_type);                                           \
-    print_traits(t_ptr);                                      \
-                                                              \
-    return {};                                                \
+#define DEFINE_PRINTER_METHOD(t_type)                           \
+  auto AstPrinter::visit([[maybe_unused]] t_type* t_ptr) -> Any \
+  {                                                             \
+    COUNTG_INIT();                                              \
+                                                                \
+    print(#t_type);                                             \
+    print_traits(t_ptr);                                        \
+                                                                \
+    return {};                                                  \
   }
 
 namespace ast::visitor {

--- a/src/crow/ast/visitor/node_visitor.cpp
+++ b/src/crow/ast/visitor/node_visitor.cpp
@@ -12,12 +12,12 @@
 // TODO: Place somewhere appropriate
 #define assert_msg(t_msg, t_expr) assert(((void)t_msg, t_expr))
 
-#define STUB(t_type)                                           \
-  auto NodeVisitor::visit([[maybe_unused]] t_type* t_ptr)->Any \
-  {                                                            \
-    DBG_WARNING("Not overriden!");                             \
-                                                               \
-    return {};                                                 \
+#define STUB(t_type)                                             \
+  auto NodeVisitor::visit([[maybe_unused]] t_type* t_ptr) -> Any \
+  {                                                              \
+    DBG_WARNING("Not overriden!");                               \
+                                                                 \
+    return {};                                                   \
   }
 
 namespace ast::visitor {

--- a/src/crow/ast/visitor/node_visitor.hpp
+++ b/src/crow/ast/visitor/node_visitor.hpp
@@ -16,7 +16,6 @@
     return {};                                             \
   }
 
-
 /* NOLINTBEGIN */
 namespace ast::visitor {
 // Using statements:
@@ -97,6 +96,7 @@ class NodeVisitor {
   virtual ~NodeVisitor() = default;
 };
 } // namespace ast::visitor
+
 /* NOLINTEND */
 
 #endif // CROW_CROW_AST_VISITOR_NODE_VISITOR_HPP

--- a/src/crow/ast/visitor/node_visitor.hpp
+++ b/src/crow/ast/visitor/node_visitor.hpp
@@ -16,8 +16,8 @@
     return {};                                             \
   }
 
-/* NOLINTBEGIN */
 
+/* NOLINTBEGIN */
 namespace ast::visitor {
 // Using statements:
 using node::NodePtr;
@@ -97,5 +97,6 @@ class NodeVisitor {
   virtual ~NodeVisitor() = default;
 };
 } // namespace ast::visitor
+/* NOLINTEND */
 
 #endif // CROW_CROW_AST_VISITOR_NODE_VISITOR_HPP

--- a/src/crow/ast/visitor/node_visitor.hpp
+++ b/src/crow/ast/visitor/node_visitor.hpp
@@ -9,11 +9,11 @@
 
 
 // Macros:
-#define AST_VISITOR_STUB(t_class, t_type)                  \
-  /* NOLINTBEGIN */                                        \
-  auto t_class::visit([[maybe_unused]] t_type* t_ptr)->Any \
-  {                                                        \
-    return {};                                             \
+#define AST_VISITOR_STUB(t_class, t_type)                    \
+  /* NOLINTBEGIN */                                          \
+  auto t_class::visit([[maybe_unused]] t_type* t_ptr) -> Any \
+  {                                                          \
+    return {};                                               \
   }
 
 /* NOLINTBEGIN */

--- a/src/crow/ast/visitor/visitable.hpp
+++ b/src/crow/ast/visitor/visitable.hpp
@@ -6,14 +6,14 @@
 
 
 // Macros:
-#define AST_VISITOR_MAKE_VISITABLE(t_visitor_type)                   \
-  auto accept(t_visitor_type* t_visitor)->ast::visitor::Any override \
-  {                                                                  \
-    return {t_visitor->visit(this)};                                 \
+#define AST_VISITOR_MAKE_VISITABLE(t_visitor_type)                     \
+  auto accept(t_visitor_type* t_visitor) -> ast::visitor::Any override \
+  {                                                                    \
+    return {t_visitor->visit(this)};                                   \
   }
 
 #define AST_VISITOR_VISITABLE_PURE_ACCEPT(t_visitor_type) \
-  auto accept(t_visitor_type*)->ast::visitor::Any override = 0
+  auto accept(t_visitor_type*) -> ast::visitor::Any override = 0
 
 namespace ast::visitor {
 // We use std::any to allow a visitor to return anything

--- a/src/crow/banner.cpp
+++ b/src/crow/banner.cpp
@@ -1,6 +1,5 @@
 #include "banner.hpp"
 
-
 auto make_banner() -> std::string
 {
   using namespace rang;

--- a/src/crow/check/check.hpp
+++ b/src/crow/check/check.hpp
@@ -24,12 +24,12 @@ using TypeList = std::list<SymbolData>;
 } // namespace check
 
 // Functions:
-auto operator<<(std::ostream& t_os, check::StructTypePtr t_struct)
-  -> std::ostream&;
+auto operator<<(std::ostream& t_os,
+                check::StructTypePtr t_struct) -> std::ostream&;
 auto operator<<(std::ostream& t_os, check::FnTypePtr t_fn) -> std::ostream&;
 auto operator<<(std::ostream& t_os, check::VarTypePtr t_var) -> std::ostream&;
 
-auto operator<<(std::ostream& t_os, const check::TypeList& t_list)
-  -> std::ostream&;
+auto operator<<(std::ostream& t_os,
+                const check::TypeList& t_list) -> std::ostream&;
 
 #endif // CROW_CROW_CHECK_CHECK_HPP

--- a/src/crow/check/env_stack.cpp
+++ b/src/crow/check/env_stack.cpp
@@ -20,8 +20,8 @@ EnvStack::EnvStack(): m_envs{}
   m_envs.emplace_back();
 }
 
-auto EnvStack::add_symbol(const std::string_view t_id, const SymbolData t_data)
-  -> void
+auto EnvStack::add_symbol(const std::string_view t_id,
+                          const SymbolData t_data) -> void
 {
   Symbol pair{t_id, t_data};
 

--- a/src/crow/check/env_stack.cpp
+++ b/src/crow/check/env_stack.cpp
@@ -46,7 +46,7 @@ auto EnvStack::get_symbol(const std::string_view t_id) -> SymbolData
       data = iter->second;
 
       DBG_INFO("Found Symbol ", str, " of type ", data, " in Env!");
-			break;
+      break;
     }
   }
 

--- a/src/crow/check/symbol_data.cpp
+++ b/src/crow/check/symbol_data.cpp
@@ -41,7 +41,8 @@ auto SymbolData::is_const() const -> bool
     return false;
   }};
 
-  const auto not_const{[]([[maybe_unused]] const auto& t_data) {
+  const auto not_const{[]([[maybe_unused]]
+                          const auto& t_data) {
     return false;
   }};
 
@@ -109,8 +110,8 @@ auto SymbolData::strip() const -> TypeVariant
 } // namespace check
 
 // Functions:
-auto operator<<(std::ostream& t_os, const check::SymbolData& t_data)
-  -> std::ostream&
+auto operator<<(std::ostream& t_os,
+                const check::SymbolData& t_data) -> std::ostream&
 {
   std::visit(
     [&](auto&& t_v) {

--- a/src/crow/check/symbol_data.hpp
+++ b/src/crow/check/symbol_data.hpp
@@ -40,7 +40,7 @@ class SymbolData : public Variant {
 } // namespace check
 
 // Functions:
-auto operator<<(std::ostream& t_os, const check::SymbolData& t_data)
-  -> std::ostream&;
+auto operator<<(std::ostream& t_os,
+                const check::SymbolData& t_data) -> std::ostream&;
 
 #endif // CROW_CROW_CHECK_SYMBOL_DATA_HPP

--- a/src/crow/check/type_promoter.hpp
+++ b/src/crow/check/type_promoter.hpp
@@ -30,8 +30,8 @@ class TypePromoter {
   TypeLadder m_uint;
 
   protected:
-  auto get_priority(const TypeLadder& t_ladder, NativeType t_type) const
-    -> TypeLadder::mapped_type;
+  auto get_priority(const TypeLadder& t_ladder,
+                    NativeType t_type) const -> TypeLadder::mapped_type;
 
   public:
   TypePromoter();

--- a/src/crow/codegen/cpp_backend/clang_frontend_invoker.cpp
+++ b/src/crow/codegen/cpp_backend/clang_frontend_invoker.cpp
@@ -79,8 +79,8 @@ auto ClangFrontendInvoker::compile(const path &t_filepath) -> void
   DBG_INFO("binary: ", binary);
 
   // FIXME: This is a temporary workaround till the programmatic approach works.
-  const auto cmd{
-    std::format("g++ {} -g3 -ggdb -o {}", t_filepath.native(), binary.native())};
+  const auto cmd{std::format("g++ {} -g3 -ggdb -o {}", t_filepath.native(),
+                             binary.native())};
   const auto status_code{std::system(cmd.c_str())};
 
   if(status_code == 0) {

--- a/src/crow/codegen/llvm_backend/llvm_backend.cpp
+++ b/src/crow/codegen/llvm_backend/llvm_backend.cpp
@@ -94,7 +94,8 @@ auto LlvmBackend::visit(If* t_if) -> Any
 
   fn->insert(fn->end(), merge);
   m_builder->SetInsertPoint(merge);
-  [[maybe_unused]] auto* pn{
+  [[maybe_unused]]
+  auto* pn{
     m_builder->CreatePHI(llvm::Type::getDoubleTy(*m_context), 2, "iftmp")};
 
   // Figure this out?

--- a/src/crow/container/source_position.hpp
+++ b/src/crow/container/source_position.hpp
@@ -18,8 +18,8 @@ struct SourcePosition {
   SourcePosition(std::string_view t_source, std::size_t t_line_nr,
                  std::string_view t_function);
 
-  friend auto operator<<(std::ostream& t_os, const SourcePosition& t_sp)
-    -> std::ostream&;
+  friend auto operator<<(std::ostream& t_os,
+                         const SourcePosition& t_sp) -> std::ostream&;
 
   virtual ~SourcePosition() = default;
 };

--- a/src/crow/container/text_buffer.hpp
+++ b/src/crow/container/text_buffer.hpp
@@ -39,8 +39,8 @@ class TextBuffer : public TextStream {
 
   auto position() const -> TextPosition override;
 
-  friend auto operator<<(std::ostream& t_os, const TextBuffer& t_tb)
-    -> std::ostream&;
+  friend auto operator<<(std::ostream& t_os,
+                         const TextBuffer& t_tb) -> std::ostream&;
 
   virtual ~TextBuffer() = default;
 };

--- a/src/crow/container/text_position.hpp
+++ b/src/crow/container/text_position.hpp
@@ -22,8 +22,8 @@ struct TextPosition {
   TextPosition(std::string_view t_source, std::string_view t_line,
                std::size_t t_lineno, std::size_t t_columnno);
 
-  friend auto operator<<(std::ostream& t_os, const TextPosition& t_fp)
-    -> std::ostream&;
+  friend auto operator<<(std::ostream& t_os,
+                         const TextPosition& t_fp) -> std::ostream&;
 
   virtual ~TextPosition() = default;
 };

--- a/src/crow/debug/log.hpp
+++ b/src/crow/debug/log.hpp
@@ -18,7 +18,7 @@ using container::SourcePosition;
 
 // Functions:
 template<typename... Args>
-auto print(Args&&... t_args) -> void
+auto print(Args &&...t_args) -> void
 {
   // We use std::clog for logging.
   (std::clog << ... << t_args);
@@ -29,7 +29,7 @@ auto print(Args&&... t_args) -> void
 }
 
 template<typename... Args>
-auto println(Args&&... t_args) -> void
+auto println(Args &&...t_args) -> void
 {
   // Fold expression
   print(std::forward<Args>(t_args)..., '\n');
@@ -45,8 +45,8 @@ auto println(Args&&... t_args) -> void
  * @param[in] t_args Arguments to log.
  */
 template<typename... Args>
-inline auto log(const SourcePosition t_pos, LogLevel t_loglevel,
-                Args&&... t_args) -> void
+inline auto log(SourcePosition &&t_pos, LogLevel t_loglevel, Args &&...t_args)
+  -> void
 {
   using namespace rang;
 

--- a/src/crow/debug/log.hpp
+++ b/src/crow/debug/log.hpp
@@ -45,8 +45,8 @@ auto println(Args &&...t_args) -> void
  * @param[in] t_args Arguments to log.
  */
 template<typename... Args>
-inline auto log(SourcePosition &&t_pos, LogLevel t_loglevel, Args &&...t_args)
-  -> void
+inline auto log(SourcePosition &&t_pos, LogLevel t_loglevel,
+                Args &&...t_args) -> void
 {
   using namespace rang;
 

--- a/src/crow/debug/loglevel.cpp
+++ b/src/crow/debug/loglevel.cpp
@@ -26,8 +26,8 @@ auto set_loglevel(const LogLevel t_loglevel) -> void
 } // namespace debug
 
 // Functions:
-auto operator<<(std::ostream& t_os, const debug::LogLevel t_loglevel)
-  -> std::ostream&
+auto operator<<(std::ostream& t_os,
+                const debug::LogLevel t_loglevel) -> std::ostream&
 {
   using namespace rang;
 

--- a/src/crow/debug/loglevel.hpp
+++ b/src/crow/debug/loglevel.hpp
@@ -84,7 +84,7 @@ auto set_loglevel(LogLevel t_loglevel) -> void;
 } // namespace debug
 
 // Functions:
-auto operator<<(std::ostream& t_os, debug::LogLevel t_loglevel)
-  -> std::ostream&;
+auto operator<<(std::ostream& t_os,
+                debug::LogLevel t_loglevel) -> std::ostream&;
 
 #endif // CROW_CROW_DEBUG_LOGLEVEL_HPP

--- a/src/crow/debug/trace_macros.hpp
+++ b/src/crow/debug/trace_macros.hpp
@@ -7,21 +7,25 @@
 
 // Macros:
 #ifdef DEBUG
-#define DBG_TRACE_INIT() int m_counter__{0}
+#define DBG_TRACE_INIT() \
+  int m_counter__        \
+  {                      \
+    0                    \
+  }
 
 // TRACE is intended for showing which functions call which in a tree like
 // manner
-#define DBG_TRACE(loglevel, ...)                      \
-  debug::Trace CONCAT(trace, __COUNTER__)             \
-  {                                                   \
+#define DBG_TRACE(loglevel, ...)                        \
+  debug::Trace CONCAT(trace, __COUNTER__)               \
+  {                                                     \
     m_counter__, debug::LogLevel::loglevel, __VA_ARGS__ \
   }
 
 // Creates a trace object in an enclosed scope, usefull for printing TRACE info
 // on the same level within a function
-#define DBG_TRACE_PRINT(loglevel, ...)                    \
-  do {                                                    \
-    debug::Trace CONCAT(trace, __COUNTER__){              \
+#define DBG_TRACE_PRINT(loglevel, ...)                      \
+  do {                                                      \
+    debug::Trace CONCAT(trace, __COUNTER__){                \
       m_counter__, debug::LogLevel::loglevel, __VA_ARGS__}; \
   } while(false)
 

--- a/src/crow/exception/syntax_error.hpp
+++ b/src/crow/exception/syntax_error.hpp
@@ -20,7 +20,8 @@ using container::TextPosition;
  */
 class SyntaxError : public Error {
   private:
-  auto format(std::string_view t_msg, const TextPosition& t_pos) const -> std::string;
+  auto format(std::string_view t_msg, const TextPosition& t_pos) const
+    -> std::string;
 
   protected:
   container::TextPosition m_pos;

--- a/src/crow/exception/syntax_error.hpp
+++ b/src/crow/exception/syntax_error.hpp
@@ -20,8 +20,8 @@ using container::TextPosition;
  */
 class SyntaxError : public Error {
   private:
-  auto format(std::string_view t_msg, const TextPosition& t_pos) const
-    -> std::string;
+  auto format(std::string_view t_msg,
+              const TextPosition& t_pos) const -> std::string;
 
   protected:
   container::TextPosition m_pos;

--- a/src/crow/parser/crow/CMakeLists.txt
+++ b/src/crow/parser/crow/CMakeLists.txt
@@ -1,4 +1,7 @@
-# Add source files
+# Add source files.
 target_sources(${TARGET_CROW_LIB} PRIVATE
 	crow_parser.cpp
 )
+
+# Add subdirectories.
+add_subdirectory(context)

--- a/src/crow/parser/crow/context/CMakeLists.txt
+++ b/src/crow/parser/crow/context/CMakeLists.txt
@@ -1,0 +1,5 @@
+# Add source files.
+target_sources(${TARGET_CROW_LIB} PRIVATE
+	context_store.cpp
+	context_guard.cpp
+)

--- a/src/crow/parser/crow/context/context_guard.cpp
+++ b/src/crow/parser/crow/context/context_guard.cpp
@@ -1,0 +1,14 @@
+#include "context_guard.hpp"
+
+namespace parser::crow::context {
+ContextGuard::ContextGuard(const Context t_context, ContextStore& t_store)
+  : m_context{t_context}, m_store{t_store}
+{
+  m_store.set(m_context);
+}
+
+ContextGuard::~ContextGuard()
+{
+  m_store.clear(m_context);
+}
+} // namespace parser::crow::context

--- a/src/crow/parser/crow/context/context_guard.hpp
+++ b/src/crow/parser/crow/context/context_guard.hpp
@@ -1,0 +1,23 @@
+#ifndef CONTEXT_GUARD_HPP
+#define CONTEXT_GUARD_HPP
+
+// Local Includes:
+#include "context_store.hpp"
+
+namespace parser::crow::context {
+/*!
+ * Convienence class that is used to manage a context by using object lifetime.
+ */
+class ContextGuard {
+  private:
+  Context m_context;
+  ContextStore& m_store;
+
+  public:
+  ContextGuard(Context t_context, ContextStore& t_store);
+
+  virtual ~ContextGuard();
+};
+} // namespace parser::crow::context
+
+#endif // CONTEXT_GUARD_HPP

--- a/src/crow/parser/crow/context/context_store.cpp
+++ b/src/crow/parser/crow/context/context_store.cpp
@@ -1,0 +1,28 @@
+#include "context_store.hpp"
+
+namespace parser::crow::context {
+ContextStore::ContextStore(): m_store{}
+{}
+
+auto ContextStore::set(const Context t_context) -> void
+{
+  m_store[t_context] = true;
+}
+
+auto ContextStore::clear(const Context t_context) -> void
+{
+  m_store[t_context] = false;
+}
+
+auto ContextStore::get(const Context t_context) -> bool
+{
+  bool enabled{false};
+
+  const auto iter{m_store.find(t_context)};
+  if(iter != m_store.end()) {
+    enabled = iter->second;
+  }
+
+  return enabled;
+}
+} // namespace parser::context

--- a/src/crow/parser/crow/context/context_store.cpp
+++ b/src/crow/parser/crow/context/context_store.cpp
@@ -25,4 +25,4 @@ auto ContextStore::get(const Context t_context) -> bool
 
   return enabled;
 }
-} // namespace parser::context
+} // namespace parser::crow::context

--- a/src/crow/parser/crow/context/context_store.hpp
+++ b/src/crow/parser/crow/context/context_store.hpp
@@ -1,0 +1,34 @@
+#ifndef CONTEXT_VALIDATOR_HPP
+#define CONTEXT_VALIDATOR_HPP
+
+// STL Includes:
+#include <unordered_map>
+
+namespace parser::crow::context {
+// Enums:
+//! Possible contexts to be parsing in.
+enum class Context {
+  LOOP,
+};
+
+// Aliases:
+using ContextMap = std::unordered_map<Context, bool>;
+
+// Classes:
+class ContextStore {
+  private:
+  ContextMap m_store;
+
+  public:
+  ContextStore();
+
+  auto set(Context t_context) -> void;
+  auto clear(Context t_context) -> void;
+
+  auto get(Context t_context) -> bool;
+
+  virtual ~ContextStore() = default;
+};
+} // namespace parser::crow::context
+
+#endif // CONTEXT_VALIDATOR_HPP

--- a/src/crow/parser/crow/crow.yy
+++ b/src/crow/parser/crow/crow.yy
@@ -174,6 +174,7 @@ expr_list_opt    : // empty
                  ;
 
 // Jump statement:
+// Continue and Break are only allowed to be used in loops.
 jump_statement   : Continue terminator
                  | Break terminator
                  | Defer expr_statement
@@ -207,22 +208,22 @@ match_statement  : Match match_body
 
 // Branch statements:
 if_statement     : If eval_expr body
-				         | If eval_expr body Else body
-				         | If eval_expr body elif_statement
+		 | If eval_expr body Else body
+		 | If eval_expr body elif_statement
                  ;
 
 elif_statement   : ElIf eval_expr body
-				         | ElIf eval_expr body Else body
-				         | ElIf eval_expr body elif_statement
+		 | ElIf eval_expr body Else body
+		 | ElIf eval_expr body elif_statement
                  ;
 
 // Statements:
 statement        : result_statement
-				         | if_statement
-				         | match_statement
-				         | loop_statement
-				         | keyword_statement
-				         | body
+		 | if_statement
+		 | match_statement
+		 | loop_statement
+		 | keyword_statement
+		 | body
                  ;
 
 statement_list   : statement newline_opt
@@ -236,12 +237,12 @@ body             : newline_opt '{' newline_opt '}'
 
 // Attributes:
 attribute        : Private
-				         | Public
+		 | Public
                  ;
 
 // Typing:
-// TODO:
-/* alias_def        : Use? */
+// TODO: Figure out how to name aliases?
+/* alias_def     : Alias? */
 
 // Enum:
 enum_def         : Enum IDENTIFIER newline_opt
@@ -253,8 +254,8 @@ method_decl      : Fn IDENTIFIER '(' param_list_opt ')' return_type terminator
 
 
 method_decl_list : // empty
-				         | method_decl
-				         | fn_decl_list method_decl
+		 | method_decl
+		 | fn_decl_list method_decl
                  ;
 
 interface_def    : Interface IDENTIFIER newline_opt
@@ -267,7 +268,7 @@ member_decl      : IDENTIFIER ':' IDENTIFIER terminator
 
 member_decl_list : // empty
                  | member_decl
-				         | member_decl_list member_decl
+		 | member_decl_list member_decl
                  ;
 
 struct_def       : Struct IDENTIFIER newline_opt
@@ -284,14 +285,13 @@ def_list         : newline_opt function
                  | impl_list newline_opt function
                  ;
 
-def_block        : Def IDENTIFIER newline_opt
+def_block        : Define IDENTIFIER newline_opt
                    '{' impl_list '}'
-                 | Def IDENTIFIER newline_opt
+                 | Define IDENTIFIER newline_opt
                    '{' impl_list '}'
                  ;
 
 // Function:
-// TODO: Think about having in, out and inout specifiers like ADA?
 param_list       : IDENTIFIER ':' IDENTIFIER
                  | param_list ',' IDENTIFIER ':' IDENTIFIER
                  ;

--- a/src/crow/parser/crow/crow_parser.hpp
+++ b/src/crow/parser/crow/crow_parser.hpp
@@ -7,9 +7,14 @@
 // Absolute Includes:
 #include "crow/parser/pratt/pratt_parser.hpp"
 
+// Local Includes:
+#include "context/context_guard.hpp"
+
 namespace parser::crow {
 // Using Statements:
 using ast::node::packaging::Import;
+using context::Context;
+using context::ContextStore;
 
 // Aliases:
 using EvalPair = std::pair<NodePtr, NodePtr>;
@@ -20,6 +25,19 @@ using EvalPair = std::pair<NodePtr, NodePtr>;
  * See crow.yy for grammar specification (BNF).
  */
 class CrowParser : public pratt::PrattParser {
+  private:
+  ContextStore m_store;
+
+  protected:
+  /*!
+   * Check if a certain context is enabled.
+   *
+   * @note If the passed Context is not enabled throw a @ref SyntaxError.
+   *
+   * @param[in] t_context Context to check for.
+   */
+  auto context_check(Context t_context) -> void;
+
   public:
   CrowParser(TokenStream t_tokenstream);
 

--- a/src/crow/token/token_type.hpp
+++ b/src/crow/token/token_type.hpp
@@ -4,7 +4,6 @@
 // STL Includes:
 #include <optional>
 
-
 namespace token {
 // forward declarations:
 enum class TokenType;

--- a/src/crow/token/tokentype2str.hpp
+++ b/src/crow/token/tokentype2str.hpp
@@ -12,7 +12,7 @@ namespace token {
 auto tokentype2str(TokenType t_type) -> std::string;
 } // namespace token
 
-auto operator<<(std::ostream& t_os, const token::TokenType t_type)
-  -> std::ostream&;
+auto operator<<(std::ostream& t_os,
+                const token::TokenType t_type) -> std::ostream&;
 
 #endif // CROW_CROW_TOKEN_TOKENTYPE2STR_HPP

--- a/tasks.py
+++ b/tasks.py
@@ -73,12 +73,12 @@ def cmake_mode_args(t_mode: str) -> str:
     return args
 
 
-def cmake(t_ctx, t_mode: str, t_parallel: bool, t_lint: bool):
+def cmake(t_ctx, t_mode: str, t_parallel: bool, t_lint=False):
     ''' TODO: Document. '''
     parallel_arg = cmake_parallel_arg(t_parallel)
     build_args = cmake_mode_args(t_mode)
 
-    # Add
+    # Perform static analysis if specified.
     if t_lint:
         build_args += '-DCROW_CLANG_TIDY=TRUE'
 
@@ -110,6 +110,14 @@ def build(ctx, mode='', parallel=True, lint=False):
     '''
     Build the project.
     '''
+    print(f'@Invoke: Building project.')
+    print(f'''@Invoke: Args:
+    {{
+      mode={mode},
+      parallel={parallel},
+      lint={lint}
+    }}''')
+
     enum_values = [ item.value for item in BuildMode ]
     mode = mode if mode in enum_values else 'build'
     cmake(ctx, mode, parallel, lint)

--- a/tasks.py
+++ b/tasks.py
@@ -143,7 +143,7 @@ def format(ctx):
     '''
     Clang-format all Ctx++ sources and headers.
     '''
-    ctx.run('find src/ -iname "*.[ch]pp" -exec clang-format -i {} \;')
+    ctx.run('find src/ -iname "*.[ch]pp" -exec clang-format -i "{}" \;')
     pass
 
 @task


### PR DESCRIPTION
This prevents the `break` and `continue` keywords being used outside of loops.
Now a neat error message will be displayed.