### PR TITLE
Improved comments

### DIFF
--- a/samples/comment.cw
+++ b/samples/comment.cw
@@ -1,0 +1,9 @@
+/*!
+ * This is a documentation block.
+ * Used to document the main function.
+ */
+fn main() -> int {
+    // Here is a singular comment.
+
+    return 0
+}

--- a/samples/int.cw
+++ b/samples/int.cw
@@ -1,10 +1,10 @@
 fn main() -> int {
-    # Unsigned integers do not work currently.
-    # (type inference is not handling this properly).
-    # let var_u8: u8 = 0
-    # let var_u16: u16 = 0
-    # let var_u32: u32 = 0
-    # let var_u64: u64 = 0
+    // Unsigned integers do not work currently.
+    // (type inference is not handling this properly).
+    // let var_u8: u8 = 0
+    // let var_u16: u16 = 0
+    // let var_u32: u32 = 0
+    // let var_u64: u64 = 0
 
     let var_i8: i8 = 0
     let var_i16: i16 = 0

--- a/samples/loop.cw
+++ b/samples/loop.cw
@@ -1,5 +1,5 @@
 fn main() -> int {
-   #var empty: int
+   // var empty: int
 
    var sum = 10
    loop sum < 20; sum++ {
@@ -8,10 +8,12 @@ fn main() -> int {
    loop var index = 10; index < 20; index++ {
    }
 
-   #loop {
-     #break
-     #continue
-   #}
+   /*
+    * loop {
+    *   break
+    *   continue
+    * }
+    */
 
    return sum
 }

--- a/src/crow/container/stream.hpp
+++ b/src/crow/container/stream.hpp
@@ -3,6 +3,7 @@
 
 // STL Includes:
 #include <concepts>
+#include <iostream>
 #include <iterator>
 #include <optional>
 

--- a/src/crow/lexer/lexer.hpp
+++ b/src/crow/lexer/lexer.hpp
@@ -34,10 +34,13 @@ class Lexer {
   Lexer(TextStreamPtr t_text);
 
   // Misc:
-  auto whitespace() -> void;
+  auto newline() -> Token;
 
+  // Comment:
   auto handle_line_comment() -> Token;
   auto handle_block_comment() -> Token;
+
+  auto is_comment() -> bool;
   auto comment() -> Token;
 
   // Name:

--- a/src/crow/lexer/lexer.hpp
+++ b/src/crow/lexer/lexer.hpp
@@ -9,7 +9,7 @@
 // Absolute Includes:
 #include "crow/container/text_stream.hpp"
 #include "crow/token/reserved/reserved.hpp"
-#include "crow/token/token.hpp"
+#include "crow/token/tokenstream.hpp"
 
 namespace lexer {
 // Using Statements:
@@ -35,7 +35,7 @@ class Lexer {
 
   // Misc:
   auto whitespace() -> void;
-  auto comment() -> void;
+  auto comment() -> Token;
 
   // Name:
   static auto is_keyword(std::string_view t_identifier) -> TokenTypeOpt;

--- a/src/crow/lexer/lexer.hpp
+++ b/src/crow/lexer/lexer.hpp
@@ -35,6 +35,9 @@ class Lexer {
 
   // Misc:
   auto whitespace() -> void;
+
+  auto handle_line_comment() -> Token;
+  auto handle_block_comment() -> Token;
   auto comment() -> Token;
 
   // Name:

--- a/src/crow/parser/parser.hpp
+++ b/src/crow/parser/parser.hpp
@@ -7,7 +7,7 @@
 // Absolute Includes:
 #include "crow/ast/node/fdecl.hpp"
 #include "crow/debug/trace.hpp"
-#include "crow/token/token.hpp"
+#include "crow/token/tokenstream.hpp"
 #include "crow/token/tokentype2str.hpp"
 
 

--- a/src/crow/phases.cpp
+++ b/src/crow/phases.cpp
@@ -35,8 +35,12 @@ auto lex(const path& t_path) -> token::TokenStream
   using container::TextBuffer;
   using lexer::Lexer;
 
+  DBG_PRINTLN("<lexing>");
+
   const auto stream_ptr{std::make_shared<TextBuffer>(open_file(t_path))};
   const auto tokenstream{lex(stream_ptr)};
+
+  DBG_PRINTLN("</lexing>");
 
   return tokenstream;
 }
@@ -118,6 +122,8 @@ auto run() -> void
 {
   for(const auto& path : settings.m_paths) {
     const auto ts{lex(path)};
+    DBG_PRINTLN("TokenStream: ", ts);
+
     const auto ast{parse(ts)};
 
     print_ast(ast);

--- a/src/crow/phases.hpp
+++ b/src/crow/phases.hpp
@@ -8,10 +8,12 @@
 #include "codegen/cpp_backend/cpp_backend.hpp"
 #include "codegen/llvm_backend/llvm_backend.hpp"
 #include "container/text_buffer.hpp"
-#include "debug/log.hpp"
 #include "lexer/lexer.hpp"
 #include "parser/crow/crow_parser.hpp"
-#include "token/token.hpp"
+
+// FIXME: log has to be included as last in order to see all operator<<().
+// Add a rule for this in the .clang-format file.
+#include "debug/log.hpp"
 
 // Local Includes:
 #include "cli.hpp"

--- a/src/crow/token/CMakeLists.txt
+++ b/src/crow/token/CMakeLists.txt
@@ -1,5 +1,6 @@
 # Add source files
 target_sources(${TARGET_CROW_LIB} PRIVATE
-	token.cpp
-	tokentype2str.cpp
+  token.cpp
+  tokenstream.cpp
+  tokentype2str.cpp
 )

--- a/src/crow/token/reserved/reserved.hpp
+++ b/src/crow/token/reserved/reserved.hpp
@@ -58,25 +58,25 @@ namespace keywords {
   DEFINE_TERMINAL(g_defer,    "defer",    DEFER);
   DEFINE_TERMINAL(g_return,   "return",   RETURN);
 
-	// Literals:
+  // Literals:
   DEFINE_TERMINAL(g_true,  "True",  TRUE);
   DEFINE_TERMINAL(g_false, "False", FALSE);
 
-	// TODO: Convert keywords to boost::bimap.
+  // TODO: Convert keywords to boost::bimap.
   // const TerminalMap g_keywords2 = boost::assign::list_of<TerminalMap<std::string_view>::relation>
-	// 	(g_let.pair())
-	// 	(g_var.pair())
-	// 	(g_module.pair()) (g_import.pair()) (g_priv.pair()) (g_pub.pair())
-	// 	(g_struct.pair()) (g_interface.pair()) (g_impl.pair())
-	//   (g_fn.pair())
-	// 	(g_match.pair())
-	//   (g_if.pair()) (g_else.pair()) (g_elif.pair())
-	//   (g_loop.pair())
-	//   (g_break.pair()) (g_continue.pair()) (g_defer.pair()) (g_return.pair())
-  //   (g_true.pair()) (g_false.pair())
-  //   ;
+  // 	(g_let.pair())
+  // 	(g_var.pair())
+  // 	(g_module.pair()) (g_import.pair()) (g_priv.pair()) (g_pub.pair())
+  // 	(g_struct.pair()) (g_interface.pair()) (g_impl.pair())
+  //    (g_fn.pair())
+  // 	(g_match.pair())
+  //    (g_if.pair()) (g_else.pair()) (g_elif.pair())
+  //    (g_loop.pair())
+  //    (g_break.pair()) (g_continue.pair()) (g_defer.pair()) (g_return.pair())
+  //    (g_true.pair()) (g_false.pair())
+  //    ;
 
-	const std::map g_keywords {
+  const std::map g_keywords {
     g_let.pair(), g_var.pair(),
     g_module.pair(), g_import.pair(), g_priv.pair(), g_pub.pair(),
     g_struct.pair(), g_interface.pair(), g_impl.pair(),
@@ -120,20 +120,17 @@ namespace symbols {
 
   DEFINE_TERMINAL(g_assignment, '=',  ASSIGNMENT);
 
-	// Comparisons:
-  DEFINE_TERMINAL(g_less_than,       '<',   LESS_THAN);
+  // Comparisons:
+  DEFINE_TERMINAL(g_less_than,       '<',  LESS_THAN);
   DEFINE_TERMINAL(g_less_than_equal, "<=", LESS_THAN_EQUAL);
 
   DEFINE_TERMINAL(g_equal,     "==", EQUAL);
   DEFINE_TERMINAL(g_not_equal, "!=", NOT_EQUAL);
 
-  DEFINE_TERMINAL(g_greater_than,       '>',   GREATER_THAN);
+  DEFINE_TERMINAL(g_greater_than,       '>',  GREATER_THAN);
   DEFINE_TERMINAL(g_greater_than_equal, ">=", GREATER_THAN_EQUAL);
 
   // Logic:
-  DEFINE_TERMINAL(g_true, "true",  TRUE);
-  DEFINE_TERMINAL(g_false, "false",  FALSE);
-
   DEFINE_TERMINAL(g_not, '!',  NOT);
   DEFINE_TERMINAL(g_or,  "||", OR);
   DEFINE_TERMINAL(g_and, "&&", AND);
@@ -149,68 +146,71 @@ namespace symbols {
 
   DEFINE_TERMINAL(g_newline,  '\n', NEWLINE);
 
-	const std::map g_single_symbols {
-	  g_paren_open.pair(),
-	  g_paren_close.pair(),
-	  g_accolade_open.pair(),
-	  g_accolade_close.pair(),
-	  g_brace_open.pair(),
-	  g_brace_close.pair(),
+  const std::map g_single_symbols {
+    g_paren_open.pair(),
+    g_paren_close.pair(),
+    g_accolade_open.pair(),
+    g_accolade_close.pair(),
+    g_brace_open.pair(),
+    g_brace_close.pair(),
 
-	  g_assignment.pair(),
+    g_assignment.pair(),
 
-	  g_less_than.pair(),
-	  g_greater_than.pair(),
+    g_less_than.pair(),
+    g_greater_than.pair(),
 
-	  g_not.pair(),
+    g_not.pair(),
 
-	  g_dot.pair(),
-	  g_comma.pair(),
-	  g_question_mark.pair(),
-	  g_colon.pair(),
-	  g_semicolon.pair(),
+    g_dot.pair(),
+    g_comma.pair(),
+    g_question_mark.pair(),
+    g_colon.pair(),
+    g_semicolon.pair(),
 
-	  g_plus.pair(),
-	  g_minus.pair(),
-	  g_asterisk.pair(),
-	  g_slash.pair(),
-	  g_percent_sign.pair(),
+    g_plus.pair(),
+    g_minus.pair(),
+    g_asterisk.pair(),
+    g_slash.pair(),
+    g_percent_sign.pair(),
 
-		g_newline.pair()
+    g_newline.pair()
   };
 
-	const std::map g_multi_symbols{
-	  g_increment.pair(),
-	  g_decrement.pair(),
+  const std::map g_multi_symbols{
+    g_increment.pair(),
+    g_decrement.pair(),
 
-	  g_mul_assign.pair(),
-	  g_div_assign.pair(),
-	  g_mod_assign.pair(),
+    g_mul_assign.pair(),
+    g_div_assign.pair(),
+    g_mod_assign.pair(),
 
-	  g_add_assign.pair(),
-	  g_sub_assign.pair(),
+    g_add_assign.pair(),
+    g_sub_assign.pair(),
 
-	  g_less_than_equal.pair(),
+    g_less_than_equal.pair(),
 
-	  g_equal.pair(),
-	  g_not_equal.pair(),
+    g_equal.pair(),
+    g_not_equal.pair(),
 
-	  g_greater_than_equal.pair(),
+    g_greater_than_equal.pair(),
 
-	  g_true.pair(),
-	  g_false.pair(),
+    g_or.pair(),
+    g_and.pair(),
 
-	  g_or.pair(),
-	  g_and.pair(),
+    g_arrow.pair(),
+    g_double_colon.pair()
+  };
 
-		g_arrow.pair(),
-		g_double_colon.pair()
-	};
+  namespace none {
+    constexpr auto g_double_quote{'"'};
+    constexpr auto g_backslash{'\\'};
 
-	namespace none {
-		constexpr auto g_double_quote{'"'};
-		constexpr auto g_backslash{'\\'};
-	}
+    // These are for dealing with comments:
+    constexpr auto g_exclamation_mark{'!'};
+    constexpr auto g_slash{'/'};
+    constexpr auto g_asterisk{'*'};
+    constexpr auto g_newline{'\n'};
+  }
 } // namespace symbols
 } // namespace reserved
 

--- a/src/crow/token/token.cpp
+++ b/src/crow/token/token.cpp
@@ -1,5 +1,14 @@
 #include "token.hpp"
 
+// STL Includes:
+#include <iostream>
+
+// Local Includes:
+#include "tokentype2str.hpp"
+
+// Using statements:
+using token::Token;
+
 namespace token {
 Token::Token(const TokenType t_type, TextPosition t_tp)
   : m_type{t_type}, m_tp{std::move(t_tp)}
@@ -34,3 +43,11 @@ auto Token::position() const -> const TextPosition&
   return m_tp;
 }
 } // namespace token
+
+// Functions:
+auto operator<<(std::ostream& t_os, const Token& t_token) -> std::ostream&
+{
+  t_os << t_token.type();
+
+  return t_os;
+}

--- a/src/crow/token/token.cpp
+++ b/src/crow/token/token.cpp
@@ -2,6 +2,7 @@
 
 // STL Includes:
 #include <iostream>
+#include <sstream>
 
 // Local Includes:
 #include "tokentype2str.hpp"
@@ -10,6 +11,7 @@
 using token::Token;
 
 namespace token {
+// Methods:
 Token::Token(const TokenType t_type, TextPosition t_tp)
   : m_type{t_type}, m_tp{std::move(t_tp)}
 {}
@@ -42,12 +44,24 @@ auto Token::position() const -> const TextPosition&
 {
   return m_tp;
 }
+
+// Functions:
+auto token2str(const Token& t_token) -> std::string
+{
+  std::stringstream ss;
+
+  // TODO: Also print the value in the following format:
+  // (<type>, <value>)
+  ss << t_token.type();
+
+  return ss.str();
+}
 } // namespace token
 
 // Functions:
 auto operator<<(std::ostream& t_os, const Token& t_token) -> std::ostream&
 {
-  t_os << t_token.type();
+  t_os << token::token2str(t_token);
 
   return t_os;
 }

--- a/src/crow/token/token.hpp
+++ b/src/crow/token/token.hpp
@@ -2,12 +2,11 @@
 #define CROW_CROW_TOKEN_TOKEN_HPP
 
 // STL Includes:
+#include <iosfwd>
 #include <string>
 #include <variant>
-#include <vector>
 
 // Absolute Includes:
-#include "crow/container/stream.hpp"
 #include "crow/container/text_position.hpp"
 
 // Local Includes:
@@ -15,16 +14,12 @@
 
 namespace token {
 // Using Statements:
-using container::Stream;
 using container::TextPosition;
 
 // Forward Declarations:
 class Token;
 
 // Aliases:
-using TokenOpt = std::optional<Token>;
-using TokenVec = std::vector<Token>;
-using TokenStream = Stream<TokenVec>;
 using TokenValue = std::variant<int, double, std::string>;
 
 // Classes:
@@ -58,5 +53,9 @@ class Token {
   virtual ~Token() = default;
 };
 } // namespace token
+
+// Functions:
+auto operator<<(std::ostream& t_os, const token::Token& t_token)
+  -> std::ostream&;
 
 #endif // CROW_CROW_TOKEN_TOKEN_HPP

--- a/src/crow/token/token.hpp
+++ b/src/crow/token/token.hpp
@@ -52,6 +52,10 @@ class Token {
 
   virtual ~Token() = default;
 };
+
+// Functions:
+//! Used to convert @ref Token to a string representation.
+auto token2str(const Token& t_token) -> std::string;
 } // namespace token
 
 // Functions:

--- a/src/crow/token/token_type.hpp
+++ b/src/crow/token/token_type.hpp
@@ -97,8 +97,9 @@ enum class TokenType {
   AND,
   OR,
 
-  // Comment:
-  DOC_COMMENT,
+  // Comments:
+  LINE_COMMENT,       // Starts with "//".
+  BLOCK_COMMENT, // Starts with "/*" ends with "*/", may span multiple lines.
 
   // Miscellaneous:
   ARROW,

--- a/src/crow/token/token_type.hpp
+++ b/src/crow/token/token_type.hpp
@@ -98,7 +98,7 @@ enum class TokenType {
   OR,
 
   // Comments:
-  LINE_COMMENT,       // Starts with "//".
+  LINE_COMMENT,  // Starts with "//".
   BLOCK_COMMENT, // Starts with "/*" ends with "*/", may span multiple lines.
 
   // Miscellaneous:

--- a/src/crow/token/token_type.hpp
+++ b/src/crow/token/token_type.hpp
@@ -97,6 +97,9 @@ enum class TokenType {
   AND,
   OR,
 
+  // Comment:
+  DOC_COMMENT,
+
   // Miscellaneous:
   ARROW,
   DOT,

--- a/src/crow/token/tokenstream.cpp
+++ b/src/crow/token/tokenstream.cpp
@@ -1,5 +1,38 @@
 #include "tokenstream.hpp"
 
+#include <sstream>
+
+// Private Functions:
+namespace {
+/*!
+ * Convert a string to a raw string.
+ */
+std::string escape_str(const std::string_view& t_str)
+{
+  std::stringstream ss;
+  for(const auto ch : t_str) {
+    switch(ch) {
+      case '\\':
+        ss << "\\\\"; // Escape backslashes.
+        break;
+
+      case '"':
+        ss << "\\\""; // Escape double quotes.
+        break;
+
+      case '\n':
+        ss << "\\n"; // Escape newline.
+	break;
+
+      default:
+        ss << ch; // Append normal characters.
+        break;
+    }
+  }
+
+  return ss.str();
+}
+} // namespace
 
 auto operator<<(std::ostream& t_os, const token::TokenStream& t_ts)
   -> std::ostream&
@@ -7,7 +40,9 @@ auto operator<<(std::ostream& t_os, const token::TokenStream& t_ts)
   t_os << '[';
 
   for(const auto& tok : t_ts) {
-    t_os << tok << ", ";
+    const auto str{token::token2str(tok)};
+
+    t_os << escape_str(str) << ", ";
   }
 
   t_os << ']';

--- a/src/crow/token/tokenstream.cpp
+++ b/src/crow/token/tokenstream.cpp
@@ -5,24 +5,31 @@
 // Private Functions:
 namespace {
 /*!
- * Convert a string to a raw string.
+ * Escape all special characters and backslashes.
+ *
+ * @note FIXME: Place somewhere more appropiate, likely in src/lib.
+ * This is a utility function so it should probably go there.
  */
 std::string escape_str(const std::string_view& t_str)
 {
   std::stringstream ss;
   for(const auto ch : t_str) {
     switch(ch) {
-      case '\\':
-        ss << "\\\\"; // Escape backslashes.
-        break;
-
-      case '"':
-        ss << "\\\""; // Escape double quotes.
+      case '\t':
+        ss << "\\t"; // Escape tab.
         break;
 
       case '\n':
         ss << "\\n"; // Escape newline.
-	break;
+        break;
+
+      case '\v':
+        ss << "\\v"; // Escape vertical tab.
+        break;
+
+      case '\r':
+        ss << "\\r"; // Escape carriage return.
+        break;
 
       default:
         ss << ch; // Append normal characters.

--- a/src/crow/token/tokenstream.cpp
+++ b/src/crow/token/tokenstream.cpp
@@ -1,0 +1,16 @@
+#include "tokenstream.hpp"
+
+
+auto operator<<(std::ostream& t_os, const token::TokenStream& t_ts)
+  -> std::ostream&
+{
+  t_os << '[';
+
+  for(const auto& tok : t_ts) {
+    t_os << tok << ", ";
+  }
+
+  t_os << ']';
+
+  return t_os;
+}

--- a/src/crow/token/tokenstream.hpp
+++ b/src/crow/token/tokenstream.hpp
@@ -1,0 +1,33 @@
+#ifndef CROW_CROW_TOKEN_TOKENSTREAM_HPP
+#define CROW_CROW_TOKEN_TOKENSTREAM_HPP
+
+/*!
+ * @file
+ * This file needs to exist because the operator<<() of @ref Stream<T>.
+ * Is defined in the header as @ref Stream<T> is a templated class.
+ * First we include @ref Token so that the operator<<() of @ref Stream<T>.
+ * Sees the @ref Token operator<<().
+ * Else it wont find the candidate for it.
+ */
+
+// STL Includes:
+#include <vector>
+
+// Absolute Includes:
+#include "crow/container/stream.hpp"
+#include "crow/token/token.hpp"
+
+namespace token {
+// Using Statements:
+using container::Stream;
+
+// Aliases:
+using TokenVec = std::vector<Token>;
+using TokenStream = Stream<TokenVec>;
+} // namespace token
+
+// Functions:
+auto operator<<(std::ostream& t_os, const token::TokenStream& t_ts)
+  -> std::ostream&;
+
+#endif // CROW_CROW_TOKEN_TOKENSTREAM_HPP

--- a/src/crow/token/tokentype2str.cpp
+++ b/src/crow/token/tokentype2str.cpp
@@ -24,7 +24,7 @@
     return #t_type;
 
 // Using statements:
-using namespace token;
+using token::TokenType;
 
 namespace {
 // Aliases:

--- a/src/crow/token/tokentype2str.cpp
+++ b/src/crow/token/tokentype2str.cpp
@@ -78,6 +78,10 @@ auto tokentype2str(const token::TokenType t_type) -> std::string
     MATCH_STR(BRACE_OPEN)
     MATCH_STR(BRACE_CLOSE)
 
+    // Comments:
+    MATCH_STR(LINE_COMMENT)
+    MATCH_STR(BLOCK_COMMENT)
+
     // Miscellaneous:
     MATCH_STR(NEWLINE)
 


### PR DESCRIPTION
Comments are now written using `//` and `/*` (C style comments).
You cannot use `#` anymore for comments that feature has been removed.

I also added new `TokenType`s for the comments `LINE_COMMENT` and `BLOCK_COMMENT` respectively.
I want to have the generated C++ code contain comments.
Currently this is not supported but I need to look how feasible this is.

I also want support for documentation comments `//!` and `/*!`, I need to look into how support for this would work.
Either way better comments are implemented.