### PR TITLE
Configuration management is almost done.

### DIFF
--- a/src/crow/CMakeLists.txt
+++ b/src/crow/CMakeLists.txt
@@ -21,7 +21,7 @@ add_subdirectory(exception)
 add_subdirectory(settings)
 
 # Invokes all the phases:
-add_subdirectory(state)
+add_subdirectory(unit)
 
 # Lexing phase:
 add_subdirectory(token)

--- a/src/crow/codegen/CMakeLists.txt
+++ b/src/crow/codegen/CMakeLists.txt
@@ -1,6 +1,7 @@
 # Add source files:
 target_sources(${TARGET_CROW_LIB} PRIVATE
   backend_interface.cpp
+  interop_backend_interface.cpp
 )
 
 # Add subdirectories:

--- a/src/crow/codegen/backend_interface.cpp
+++ b/src/crow/codegen/backend_interface.cpp
@@ -29,12 +29,13 @@ auto select_backend(const BackendType t_selector) -> BackendPtr
       // With all interop backends enabled.
       // Someday we should setup a more robust way that considers project.toml.
       // And CLI option settings, but for now just do it quick and dirty.
-      auto cpp_backend{std::make_shared<CppBackend>()};
+      // auto cpp_backend{std::make_shared<CppBackend>()};
+      ptr = std::make_shared<CppBackend>();
 
-      cpp_backend->add_interop_backend(
-        std::make_shared<cpp2py_interop::PythonBackend>());
+      // cpp_backend->add_interop_backend(
+      //   std::make_shared<cpp2py_interop::PythonBackend>());
 
-      ptr = std::move(cpp_backend);
+      // ptr = std::move(cpp_backend);
       break;
     }
 

--- a/src/crow/codegen/backend_interface.hpp
+++ b/src/crow/codegen/backend_interface.hpp
@@ -17,7 +17,8 @@ using namespace ast;
 // Using Declarations:
 using node::NodePtr;
 using semantic::symbol_table::SymbolTablePtr;
-using std::filesystem::path;
+
+namespace fs = std::filesystem;
 
 // Forward Declarations:
 class BackendInterface;
@@ -49,7 +50,14 @@ class BackendInterface : public ast::visitor::NodeVisitor {
   public:
   BackendInterface() = default;
 
-  virtual auto compile(AstPack t_pack, path t_stem) -> void = 0;
+  /*!
+   * How an interop backend is added is backend specific.
+	 * So this is a shared factory method for nested interop backends.
+	 */
+  virtual auto register_interop_backend(InteropBackendType t_type) -> void = 0;
+
+  //! Compile the AST for the selected backend.
+  virtual auto compile(AstPack t_pack, fs::path t_stem) -> void = 0;
 
   virtual ~BackendInterface() = default;
 };

--- a/src/crow/codegen/cpp_backend/cpp_backend.cpp
+++ b/src/crow/codegen/cpp_backend/cpp_backend.cpp
@@ -475,7 +475,7 @@ auto CppBackend::add_interop_backend(InteropBackendPtr t_ptr) -> void
   m_interop_backends.emplace_back(t_ptr);
 }
 
-auto CppBackend::codegen(NodePtr t_ast, const path& t_out) -> void
+auto CppBackend::codegen(NodePtr t_ast, const fs::path& t_out) -> void
 {
   std::ofstream ofs{t_out};
 
@@ -495,10 +495,10 @@ auto CppBackend::codegen(NodePtr t_ast, const path& t_out) -> void
   ofs << epilogue() << '\n';
 }
 
-auto CppBackend::compile(AstPack t_pack, path t_stem) -> void
+auto CppBackend::compile(AstPack t_pack, fs::path t_stem) -> void
 {
-  const auto tmp_dir{lib::temporary_directory()};
-  const path tmp_src{tmp_dir / t_stem.concat(".cpp")};
+  const fs::path tmp_dir{lib::temporary_directory()};
+  const fs::path tmp_src{tmp_dir / t_stem.concat(".cpp")};
 
   const auto& [ast, symbol_table] = t_pack;
   m_symbol_table = symbol_table;

--- a/src/crow/codegen/cpp_backend/cpp_backend.hpp
+++ b/src/crow/codegen/cpp_backend/cpp_backend.hpp
@@ -22,8 +22,9 @@ using namespace ast;
 using interop_backends::InteropBackendPtr;
 using node::NodePtr;
 using semantic::symbol_table::SymbolTablePtr;
-using std::filesystem::path;
 using visitor::Any;
+
+namespace fs = std::filesystem;
 
 // Classes:
 /*!
@@ -150,8 +151,12 @@ class CppBackend : public BackendInterface {
   /*!
    * Transpile the @ref t_ast to valid C++ code and write it to @ref t_out.
    */
-  auto codegen(NodePtr t_ast, const path& t_out) -> void;
-  auto compile(AstPack t_pack, path t_stem) -> void override;
+  auto codegen(NodePtr t_ast, const fs::path& t_out) -> void;
+
+  //! CPP backend as of writing needs to refactor interop.
+  auto register_interop_backend([[maybe_unused]] InteropBackendType t_type)
+    -> void override {};
+  auto compile(AstPack t_pack, fs::path t_stem) -> void override;
 
   virtual ~CppBackend() = default;
 };

--- a/src/crow/codegen/interop_backend_interface.cpp
+++ b/src/crow/codegen/interop_backend_interface.cpp
@@ -1,0 +1,38 @@
+#include "interop_backend_interface.hpp"
+
+namespace codegen {
+auto interopbackendtype2str(InteropBackendType t_type) -> std::string_view
+{
+  switch(t_type) {
+    case InteropBackendType::C_INTEROP_BACKEND:
+      return "C";
+
+    case InteropBackendType::PYTHON_INTEROP_BACKEND:
+      return "python";
+
+    case InteropBackendType::LUA_INTEROP_BACKEND:
+      return "lua";
+
+    case InteropBackendType::JS_INTEROP_BACKEND:
+      return "javascript";
+
+    default:
+      throw std::invalid_argument{
+        "interopbackendtype2str() could not convert BackendType to string."};
+      break;
+  }
+
+  return {};
+}
+} // namespace codegen
+
+// Operators:
+auto operator<<(std::ostream& t_os, const codegen::InteropBackendType t_type)
+  -> std::ostream&
+{
+  using codegen::interopbackendtype2str;
+
+  t_os << interopbackendtype2str(t_type);
+
+  return t_os;
+}

--- a/src/crow/codegen/interop_backend_interface.hpp
+++ b/src/crow/codegen/interop_backend_interface.hpp
@@ -1,5 +1,5 @@
-#ifndef INTEROP_BACKEND_INTERFACE_HPP
-#define INTEROP_BACKEND_INTERFACE_HPP
+#ifndef CROW_CROW_CODEGEN_INTEROP_BACKEND_INTERFACE_HPP
+#define CROW_CROW_CODEGEN_INTEROP_BACKEND_INTERFACE_HPP
 
 // STL Includes:
 #include <memory>
@@ -60,4 +60,4 @@ auto interopbackendtype2str(InteropBackendType t_type) -> std::string_view;
 auto operator<<(std::ostream& t_os, codegen::InteropBackendType t_type)
   -> std::ostream&;
 
-#endif // INTEROP_BACKEND_INTERFACE_HPP
+#endif // CROW_CROW_CODEGEN_INTEROP_BACKEND_INTERFACE_HPP

--- a/src/crow/codegen/interop_backend_interface.hpp
+++ b/src/crow/codegen/interop_backend_interface.hpp
@@ -49,6 +49,12 @@ class InteropBackendInterface {
 
   virtual ~InteropBackendInterface() = default;
 };
+
+auto interopbackendtype2str(InteropBackendType t_type) -> std::string_view;
 } // namespace codegen
+
+// Functions:
+auto operator<<(std::ostream& t_os, codegen::InteropBackendType t_type)
+  -> std::ostream&;
 
 #endif // INTEROP_BACKEND_INTERFACE_HPP

--- a/src/crow/codegen/interop_backend_interface.hpp
+++ b/src/crow/codegen/interop_backend_interface.hpp
@@ -4,6 +4,7 @@
 // STL Includes:
 #include <memory>
 #include <string>
+#include <vector>
 
 // Absolute Includes:
 #include "crow/ast/node/fdecl.hpp"
@@ -18,8 +19,10 @@ using node::NodePtr;
 
 // Forward Declarations:
 class InteropBackendInterface;
+enum class InteropBackendType;
 
 // Aliases:
+using InteropSelectionVec = std::vector<InteropBackendType>;
 using InteropBackendPtr = std::shared_ptr<InteropBackendInterface>;
 
 // Enums:

--- a/src/crow/codegen/interop_backend_interface.hpp
+++ b/src/crow/codegen/interop_backend_interface.hpp
@@ -22,7 +22,7 @@ class InteropBackendInterface;
 enum class InteropBackendType;
 
 // Aliases:
-using InteropSelectionVec = std::vector<InteropBackendType>;
+using InteropSelectors = std::vector<InteropBackendType>;
 using InteropBackendPtr = std::shared_ptr<InteropBackendInterface>;
 
 // Enums:

--- a/src/crow/codegen/llvm_backend/llvm_backend.hpp
+++ b/src/crow/codegen/llvm_backend/llvm_backend.hpp
@@ -108,6 +108,10 @@ class LlvmBackend : public BackendInterface {
   // Util:
   auto configure_target() -> void;
   auto dump_ir(std::ostream& t_os) -> void;
+
+  //! LLVM backend as of writing supports no interop.
+  auto register_interop_backend([[maybe_unused]] InteropBackendType t_type)
+    -> void override {};
   auto compile(AstPack t_pack, path t_stem) -> void override;
 
   virtual ~LlvmBackend() = default;

--- a/src/crow/main.cpp
+++ b/src/crow/main.cpp
@@ -30,11 +30,18 @@ static auto disable_absorb_exceptions() -> void
 static auto run(settings::Settings t_settings) -> void
 {
   using unit::BuildUnit;
+  using unit::BuildUnitParams;
+  using unit::make_build_unit;
   using unit::TranslationUnit;
+
+  // Init build unit.
+  BuildUnitParams params{
+    t_settings.m_backend, t_settings.m_interop_backends, {}};
+  auto build_unit_ptr{make_build_unit(params)};
 
   // For now just compile all translation units, sequentially.
   for(const auto& path : t_settings.m_source_paths) {
-    TranslationUnit unit{path};
+    TranslationUnit unit{build_unit_ptr, path};
 
     unit.execute();
   }

--- a/src/crow/main.cpp
+++ b/src/crow/main.cpp
@@ -4,10 +4,10 @@
 // Library Includes:
 #include <cpptrace/cpptrace.hpp>
 
-// Local Includes:
-#include "debug/log.hpp"
-#include "settings/settings.hpp"
-#include "state/translation_unit.hpp"
+// Absolute Includes:
+#include "crow/debug/log.hpp"
+#include "crow/settings/settings.hpp"
+#include "crow/unit/translation_unit.hpp"
 
 // Enums:
 enum ExitCode {
@@ -29,7 +29,8 @@ static auto disable_absorb_exceptions() -> void
 
 static auto run(settings::Settings t_settings) -> void
 {
-  using state::TranslationUnit;
+  using unit::BuildUnit;
+  using unit::TranslationUnit;
 
   // For now just compile all translation units, sequentially.
   for(const auto& path : t_settings.m_source_paths) {

--- a/src/crow/main.cpp
+++ b/src/crow/main.cpp
@@ -32,7 +32,7 @@ static auto run(settings::Settings t_settings) -> void
   using state::TranslationUnit;
 
   // For now just compile all translation units, sequentially.
-  for(const auto& path : t_settings.m_paths) {
+  for(const auto& path : t_settings.m_source_paths) {
     TranslationUnit unit{path};
 
     unit.execute();

--- a/src/crow/settings/cli.cpp
+++ b/src/crow/settings/cli.cpp
@@ -21,7 +21,7 @@ using settings::Settings;
 auto add_positional_flags(CLI::App& t_app, Settings& t_settings) -> void
 {
   // Program source files:
-  t_app.add_option("{}", t_settings.m_paths, "Files to compile.")
+  t_app.add_option("{}", t_settings.m_source_paths, "Files to compile.")
     ->check(CLI::ExistingFile);
 }
 
@@ -35,7 +35,7 @@ auto add_loglevel_flag([[maybe_unused]] CLI::App& t_app, Settings& t_settings)
   const LogLevelMap& map{loglevel_map()};
 
   t_app.add_option("-l,--log-level", t_settings.m_level, "Set the LogLevel.")
-    ->transform(CLI::CheckedTransformer(map, CLI::ignore_case));
+    ->transform(CLI::CheckedTransformer(map));
 #endif // DEBUG
 }
 
@@ -49,15 +49,20 @@ auto add_backend_flag(CLI::App& t_app, Settings& t_settings) -> void
   t_app
     .add_option("-b,--backend", t_settings.m_backend,
                 "Backend to use for code generation.")
-    ->transform(CLI::CheckedTransformer(map, CLI::ignore_case));
+    ->transform(CLI::CheckedTransformer(map));
 }
 
 auto add_bindings_flag(CLI::App& t_app, Settings& t_settings) -> void
 {
+  using settings::interopbackendtype_map;
+  using settings::InteropBackendTypeMap;
 
-  // TODO: Add map with options.
-  t_app.add_option("-i,--interop", t_settings.m_interop_backends,
-                   "For which languages bindings should be generated for.");
+  const InteropBackendTypeMap& map{interopbackendtype_map()};
+
+  t_app
+    .add_option("-i,--interop", t_settings.m_interop_backends,
+                "Which interop backends should be enabled.")
+    ->transform(CLI::CheckedTransformer(map));
 }
 
 auto add_nocolor_flag(CLI::App& t_app) -> void

--- a/src/crow/settings/cli.hpp
+++ b/src/crow/settings/cli.hpp
@@ -18,9 +18,7 @@ struct Settings;
 // Structs:
 /*!
  * Utility struct for passing around the parameters needed.
- * To get the CLI parameters.
- *
- * @note
+ * For the CLI11 App and the parsing of CLI options.
  */
 struct CliParams {
   CLI::App m_app;

--- a/src/crow/settings/cli.hpp
+++ b/src/crow/settings/cli.hpp
@@ -1,5 +1,5 @@
-#ifndef CROW_CROW_CONFIG_CLI_HPP
-#define CROW_CROW_CONFIG_CLI_HPP
+#ifndef CROW_CROW_SETTINGS_CLI_HPP
+#define CROW_CROW_SETTINGS_CLI_HPP
 
 // Library Includes:
 #include <CLI/App.hpp>
@@ -51,4 +51,4 @@ class BannerFormatter : public CLI::Formatter {
 auto read_cli_settings(CliParams& t_params, Settings& t_settings) -> void;
 } // namespace settings
 
-#endif // CROW_CROW_CONFIG_CLI_HPP
+#endif // CROW_CROW_SETTINGS_CLI_HPP

--- a/src/crow/settings/enum_convert.hpp
+++ b/src/crow/settings/enum_convert.hpp
@@ -1,5 +1,5 @@
-#ifndef ENUM_CONVERT_HPP
-#define ENUM_CONVERT_HPP
+#ifndef CROW_CROW_SETTINGS_ENUM_CONVERT_HPP
+#define CROW_CROW_SETTINGS_ENUM_CONVERT_HPP
 
 /*!
  * @file Convert strings to enum types.
@@ -42,4 +42,4 @@ auto str2interopbackendtype(std::string_view t_key)
   -> codegen::InteropBackendType;
 } // namespace settings
 
-#endif // ENUM_CONVERT_HPP
+#endif // CROW_CROW_SETTINGS_ENUM_CONVERT_HPP

--- a/src/crow/settings/settings.cpp
+++ b/src/crow/settings/settings.cpp
@@ -43,9 +43,9 @@ auto operator<<(std::ostream& t_os, const settings::Settings& t_settings)
   using namespace lib::stdprint::vector;
 
   t_os << "Settings{ ";
-  t_os << "paths: " << t_settings.m_paths << ", ";
+  t_os << "source_paths: " << t_settings.m_source_paths << ", ";
   t_os << "backend: " << t_settings.m_backend << ", ";
-  t_os << "bindings: " << t_settings.m_interop_backends << ", ";
+  t_os << "interop_backends: " << t_settings.m_interop_backends << ", ";
   t_os << "loglevel: " << t_settings.m_level << ", ";
   t_os << '}';
 

--- a/src/crow/settings/settings.hpp
+++ b/src/crow/settings/settings.hpp
@@ -20,6 +20,7 @@ namespace settings {
 namespace fs = std::filesystem;
 using FileVec = std::vector<fs::path>;
 using StringVec = std::vector<std::string>;
+using InteropBackendTypeVec = std::vector<codegen::InteropBackendType>;
 
 // using InteropBackendVec = std::vector<>;
 
@@ -28,16 +29,16 @@ struct Settings {
   using BackendType = codegen::BackendType;
   using LogLevel = debug::LogLevel;
 
-  FileVec m_paths;
+  FileVec m_source_paths;
 
   codegen::BackendType m_backend;
-  StringVec m_interop_backends;
+  InteropBackendTypeVec m_interop_backends;
 
   debug::LogLevel m_level;
 
   // Methods:
   Settings()
-    : m_paths{},
+    : m_source_paths{},
       m_backend{BackendType::CPP_BACKEND},
       m_interop_backends{},
       m_level{LogLevel::VERBOSE}

--- a/src/crow/settings/settings.hpp
+++ b/src/crow/settings/settings.hpp
@@ -1,5 +1,5 @@
-#ifndef CONFIG_HPP
-#define CONFIG_HPP
+#ifndef CROW_CROW_SETTINGS_SETTINGS_HPP
+#define CROW_CROW_SETTINGS_SETTINGS_HPP
 
 // STL Includes:
 #include <filesystem>
@@ -61,4 +61,4 @@ auto get_settings(CliParams& t_params) -> Settings;
 auto operator<<(std::ostream& t_os, const settings::Settings& t_settings)
   -> std::ostream&;
 
-#endif // CONFIG_HPP
+#endif // CROW_CROW_SETTINGS_SETTINGS_HPP

--- a/src/crow/settings/toml.hpp
+++ b/src/crow/settings/toml.hpp
@@ -6,9 +6,6 @@
 #include <optional>
 #include <string_view>
 
-// Library Includes:
-#include <toml++/toml.hpp>
-
 namespace settings {
 // Forward Declarations:
 struct Settings;

--- a/src/crow/settings/toml.hpp
+++ b/src/crow/settings/toml.hpp
@@ -1,5 +1,5 @@
-#ifndef CROW_CROW_CONFIG_TOML_HPP
-#define CROW_CROW_CONFIG_TOML_HPP
+#ifndef CROW_CROW_SETTINGS_TOML_HPP
+#define CROW_CROW_SETTINGS_TOML_HPP
 
 // STL Includes:
 #include <filesystem>
@@ -29,4 +29,4 @@ auto read_settings_toml(const fs::path t_filepath, Settings& t_settings)
   -> void;
 } // namespace settings
 
-#endif // CROW_CROW_CONFIG_TOML_HPP
+#endif // CROW_CROW_SETTINGS_TOML_HPP

--- a/src/crow/unit/CMakeLists.txt
+++ b/src/crow/unit/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Add source files
 target_sources(${TARGET_CROW_LIB} PRIVATE
-  configuration_unit.cpp
+  build_unit.cpp
   translation_unit.cpp
 )

--- a/src/crow/unit/build_unit.cpp
+++ b/src/crow/unit/build_unit.cpp
@@ -3,7 +3,7 @@
 namespace state {
 
 // Functions:
-auto make_configuration_unit() -> ConfigurationUnitPtr
+auto make_configuration_unit() -> BuildUnitPtr
 {
   return {};
 }

--- a/src/crow/unit/build_unit.cpp
+++ b/src/crow/unit/build_unit.cpp
@@ -1,10 +1,42 @@
-#include "configuration_unit.hpp"
+#include "build_unit.hpp"
 
-namespace state {
+
+// Absolute Includes:
+#include "lib/filesystem.hpp"
+
+namespace unit {
+BuildUnit::BuildUnit(BackendPtr&& t_backend, fs::path t_build_dir)
+  : m_backend{std::move(t_backend)}, m_build_dir{t_build_dir}
+{}
 
 // Functions:
-auto make_configuration_unit() -> BuildUnitPtr
+auto make_build_unit(BuildUnitParams& t_params) -> BuildUnitPtr
 {
-  return {};
+  using codegen::InteropBackendType;
+  using codegen::select_backend;
+
+  BuildUnitPtr ptr{};
+
+  auto& [backend_type, interop_types, opt] = t_params;
+
+  // Get pointer to backend.
+  auto backend_ptr{select_backend(backend_type)};
+
+  // Instruct backend to add interop backends.
+  for(const InteropBackendType type : interop_types) {
+    backend_ptr->register_interop_backend(type);
+  }
+
+  // Set build dir.
+  fs::path build_dir{};
+  if(opt) {
+    build_dir = opt.value();
+  } else {
+    build_dir = lib::temporary_directory();
+  }
+
+  ptr = std::make_shared<BuildUnit>(std::move(backend_ptr), build_dir);
+
+  return ptr;
 }
-} // namespace state
+} // namespace unit

--- a/src/crow/unit/build_unit.hpp
+++ b/src/crow/unit/build_unit.hpp
@@ -2,41 +2,64 @@
 #define CROW_CROW_STATE_CONFIGURATION_UNIT_HPP
 
 // STL Includes:
+#include <filesystem>
 #include <memory>
 #include <string>
 #include <vector>
 
-namespace state {
+// Absolute Includes:
+#include "crow/codegen/backend_interface.hpp"
+
+namespace unit {
 // Forward Declarations:
 class BuildUnit;
 
 // Aliases:
-using BackendNameVec = std::vector<std::string>;
+namespace fs = std::filesystem;
+
+using codegen::BackendPtr;
+using codegen::BackendType;
+using codegen::InteropSelectors;
+
 using BuildUnitPtr = std::shared_ptr<BuildUnit>;
+using PathOpt = std::optional<fs::path>;
 
 // Structs:
+struct BuildUnitParams {
+  BackendType m_backend_selector;
+  InteropSelectors m_interop_selectors;
+  PathOpt m_build_dir_opt;
+};
+
 struct Config {
-  BackendNameVec m_backends;
+  // Other build configuration options.
+  // Maybe I will need a configuration_unit later down the line.
+  // For all of the different types of settings needed at various points.
+  // In the build process.
 };
 
 // Classes:
 /*!
  * Stores the configuration for each @ref TranslationUnit.
- * This includes which backends to use.
+ * This includes the instantiated backends.
+ * And which build dir should be used.
  */
 class BuildUnit {
   private:
-  Config m_config;
+  BackendPtr m_backend;
+  fs::path m_build_dir;
 
   public:
-  BuildUnit();
+  BuildUnit(BackendPtr&& t_backend, fs::path t_build_dir);
+
+  auto build_dir() -> const fs::path&;
 
   virtual ~BuildUnit() = default;
 };
 
 // Functions:
 //! Resolve CLI settings and configuration from project.toml.
-auto make_build_unit() -> BuildUnitPtr;
-} // namespace state
+auto make_build_unit(BuildUnitParams& t_params) -> BuildUnitPtr;
+} // namespace unit
 
 #endif // CROW_CROW_STATE_CONFIGURATION_UNIT_HPP

--- a/src/crow/unit/build_unit.hpp
+++ b/src/crow/unit/build_unit.hpp
@@ -8,11 +8,11 @@
 
 namespace state {
 // Forward Declarations:
-class ConfigurationUnit;
+class BuildUnit;
 
 // Aliases:
 using BackendNameVec = std::vector<std::string>;
-using ConfigurationUnitPtr = std::shared_ptr<ConfigurationUnit>;
+using BuildUnitPtr = std::shared_ptr<BuildUnit>;
 
 // Structs:
 struct Config {
@@ -24,19 +24,19 @@ struct Config {
  * Stores the configuration for each @ref TranslationUnit.
  * This includes which backends to use.
  */
-class ConfigurationUnit {
+class BuildUnit {
   private:
   Config m_config;
 
   public:
-  ConfigurationUnit();
+  BuildUnit();
 
-  virtual ~ConfigurationUnit() = default;
+  virtual ~BuildUnit() = default;
 };
 
 // Functions:
 //! Resolve CLI settings and configuration from project.toml.
-auto make_configuration_unit() -> ConfigurationUnitPtr;
+auto make_build_unit() -> BuildUnitPtr;
 } // namespace state
 
 #endif // CROW_CROW_STATE_CONFIGURATION_UNIT_HPP

--- a/src/crow/unit/build_unit.hpp
+++ b/src/crow/unit/build_unit.hpp
@@ -52,6 +52,7 @@ class BuildUnit {
   public:
   BuildUnit(BackendPtr&& t_backend, fs::path t_build_dir);
 
+  // auto compile(AstPack t_pack) -> void;
   auto build_dir() -> const fs::path&;
 
   virtual ~BuildUnit() = default;

--- a/src/crow/unit/translation_unit.cpp
+++ b/src/crow/unit/translation_unit.cpp
@@ -47,8 +47,9 @@ auto read_file(const path t_path) -> TextBuffer
 
 namespace unit {
 // Methods:
-TranslationUnit::TranslationUnit(const path t_source_file)
-  : m_source_file{t_source_file}
+TranslationUnit::TranslationUnit(BuildUnitPtr t_build_unit,
+                                 const path t_source_file)
+  : m_build_unit{std::move(t_build_unit)}, m_source_file{t_source_file}
 {}
 
 auto TranslationUnit::lex(const TextStreamPtr& t_text_stream) -> TokenStream

--- a/src/crow/unit/translation_unit.cpp
+++ b/src/crow/unit/translation_unit.cpp
@@ -45,7 +45,7 @@ auto read_file(const path t_path) -> TextBuffer
 }
 } // namespace
 
-namespace state {
+namespace unit {
 // Methods:
 TranslationUnit::TranslationUnit(const path t_source_file)
   : m_source_file{t_source_file}
@@ -156,4 +156,4 @@ auto TranslationUnit::execute() -> void
 
   backend({m_ast, m_symbol_table});
 }
-} // namespace state
+} // namespace unit

--- a/src/crow/unit/translation_unit.hpp
+++ b/src/crow/unit/translation_unit.hpp
@@ -51,7 +51,7 @@ class TranslationUnit {
   TranslationUnitPhase m_phase;
 
   // Config:
-  BuildUnitPtr m_config;
+  BuildUnitPtr m_build_unit;
 
   // Data:
   path m_source_file;
@@ -61,7 +61,7 @@ class TranslationUnit {
   SymbolTablePtr m_symbol_table;
 
   public:
-  TranslationUnit(path t_source_file);
+  TranslationUnit(BuildUnitPtr t_build_unit, path t_source_file);
 
   //! Tokenize the text buffer.
   virtual auto lex(const TextStreamPtr& t_text_stream) -> TokenStream;

--- a/src/crow/unit/translation_unit.hpp
+++ b/src/crow/unit/translation_unit.hpp
@@ -13,7 +13,7 @@
 #include "crow/unit/build_unit.hpp"
 #include "crow/token/token_stream.hpp"
 
-namespace state {
+namespace unit {
 // Using Statements:
 using ast::node::NodePtr;
 using codegen::AstPack;
@@ -51,7 +51,7 @@ class TranslationUnit {
   TranslationUnitPhase m_phase;
 
   // Config:
-  ConfigurationUnitPtr m_config;
+  BuildUnitPtr m_config;
 
   // Data:
   path m_source_file;
@@ -85,9 +85,9 @@ class TranslationUnit {
 };
 } // namespace state
 
-auto operator<<(std::ostream& t_os, state::TranslationUnitPhase t_phase)
+auto operator<<(std::ostream& t_os, unit::TranslationUnitPhase t_phase)
   -> std::ostream&;
-auto operator<<(std::ostream& t_os, state::TranslationUnit t_unit)
+auto operator<<(std::ostream& t_os, unit::TranslationUnit t_unit)
   -> std::ostream&;
 
 #endif // CROW_CROW_STATE_TRANSLATION_UNIT_HPP

--- a/src/crow/unit/translation_unit.hpp
+++ b/src/crow/unit/translation_unit.hpp
@@ -10,7 +10,7 @@
 #include "crow/codegen/backend_interface.hpp"
 #include "crow/container/text_buffer.hpp"
 #include "crow/semantic/symbol_table/symbol_table.hpp"
-#include "crow/state/configuration_unit.hpp"
+#include "crow/unit/build_unit.hpp"
 #include "crow/token/token_stream.hpp"
 
 namespace state {

--- a/src/lib/stdprint.hpp
+++ b/src/lib/stdprint.hpp
@@ -1,5 +1,5 @@
-#ifndef STDPRINT_HPP
-#define STDPRINT_HPP
+#ifndef CROW_LIB_STDPRINT_HPP
+#define CROW_LIB_STDPRINT_HPP
 
 /*!
  * @file Utilities for printing standard library containers.
@@ -90,4 +90,4 @@ using namespace lib::stdprint::array;
 } // namespace all
 } // namespace lib::stdprint
 
-#endif // STDPRINT_HPP
+#endif // CROW_LIB_STDPRINT_HPP


### PR DESCRIPTION
I almost have cli args that arrive at the backend orchestration.
Allowing me to specify which backends to use from the CLI as well as TOML.
This will allow me to fix the ugly way the current interop backend selection works for the CPP backend.
As well as allowing me to more clearly work on
Fixing the interop backend instantation as the temporary form if it now is shit.

And I just want to compile using only clang compilation.
The build unit will allow us an optimization as we dont need to reinstantiate the backend everytime.
For every Translation unit.

We will most likely need a config unit for certain more complex settings at a certain time.
Also a new exception/error for unsupported backends is likely required at some point.