### PR TITLE
Create alone standing typing module.

### DIFF
--- a/src/crow/ast/node/node_traits/typing/type_variant.cpp
+++ b/src/crow/ast/node/node_traits/typing/type_variant.cpp
@@ -31,6 +31,8 @@ auto TypeVariant::var() const -> VarTypePtr
 //! Resolves the @ref TypeVariant to a @ref NativeType if possible.
 auto TypeVariant::native_type() const -> NativeTypeOpt
 {
+  using lib::Overload;
+
   NativeTypeOpt opt;
 
   const auto native{[&](const NativeType t_type) -> NativeTypeOpt {

--- a/src/crow/ast/visitor/ast_archive.hpp
+++ b/src/crow/ast/visitor/ast_archive.hpp
@@ -7,7 +7,7 @@
 // Absolute Includes:
 #include "crow/exception/error.hpp"
 #include "lib/overload.hpp"
-#include "lib/types.hpp"
+#include "lib/stdtypes.hpp"
 
 // Relative AST Includes:
 #include "../node/include_nodes.hpp"
@@ -70,6 +70,7 @@ class AstArchive : public NodeVisitor {
   auto archive(Args&&... t_args) -> void
   {
     using exception::error;
+    using lib::Overload;
 
     const auto fn_archive{[&](auto&& t_archive) {
       t_archive(std::forward<Args>(t_args)...);

--- a/src/crow/clir/clir.hpp
+++ b/src/crow/clir/clir.hpp
@@ -16,7 +16,7 @@
 
 // Absolute Includes:
 #include "crow/ast/node/node_traits/typing/typing.hpp"
-#include "lib/types.hpp"
+#include "lib/stdtypes.hpp"
 
 namespace clir {
 // Forward Declarations:

--- a/src/crow/clir/fdecl.hpp
+++ b/src/crow/clir/fdecl.hpp
@@ -10,7 +10,7 @@
 #include <vector>
 
 // Absolute Includes:
-#include "lib/types.hpp"
+#include "lib/stdtypes.hpp"
 
 namespace clir {
 // Forward Declarations:

--- a/src/crow/codegen/cpp_backend/clang_frontend_invoker.cpp
+++ b/src/crow/codegen/cpp_backend/clang_frontend_invoker.cpp
@@ -10,7 +10,7 @@
 
 // Local Includes:
 #include "crow/debug/log.hpp"
-#include "lib/types.hpp"
+#include "lib/stdtypes.hpp"
 
 namespace codegen::cpp_backend {
 // Using Statements:

--- a/src/crow/codegen/cpp_backend/cpp_backend.cpp
+++ b/src/crow/codegen/cpp_backend/cpp_backend.cpp
@@ -11,7 +11,7 @@
 #include "crow/codegen/cpp_backend/interop/python_backend/python_backend.hpp"
 #include "crow/debug/log.hpp"
 #include "crow/exception/error.hpp"
-#include "lib/types.hpp"
+#include "lib/stdtypes.hpp"
 
 // Local Includes:
 #include "clang_frontend_invoker.hpp"

--- a/src/crow/codegen/cpp_backend/cpp_backend.hpp
+++ b/src/crow/codegen/cpp_backend/cpp_backend.hpp
@@ -11,7 +11,7 @@
 #include "crow/codegen/cpp_backend/interop/cpp_interop_backend_interface.hpp"
 #include "crow/semantic/symbol_table/symbol_table.hpp"
 #include "lib/filesystem.hpp"
-#include "lib/types.hpp"
+#include "lib/stdtypes.hpp"
 
 namespace codegen::cpp_backend {
 // Aliases:

--- a/src/crow/codegen/cpp_backend/interop/cpp_interop_backend_interface.hpp
+++ b/src/crow/codegen/cpp_backend/interop/cpp_interop_backend_interface.hpp
@@ -8,7 +8,7 @@
 // Absolute Includes:
 #include "crow/ast/node/fdecl.hpp"
 #include "crow/codegen/interop_backend_interface.hpp"
-#include "lib/types.hpp"
+#include "lib/stdtypes.hpp"
 
 namespace codegen::cpp_backend::interop {
 // Forward Declarations:

--- a/src/crow/codegen/cpp_backend/type_variant2cpp_type.cpp
+++ b/src/crow/codegen/cpp_backend/type_variant2cpp_type.cpp
@@ -82,6 +82,8 @@ NODE_USING_ALL_NAMESPACES()
 
 auto type_variant2cpp_type(const TypeVariant& t_variant) -> std::string_view
 {
+  using lib::Overload;
+
   std::string_view str{};
 
   if(const auto opt{t_variant.native_type()}; opt) {

--- a/src/crow/codegen/interop_backend_interface.hpp
+++ b/src/crow/codegen/interop_backend_interface.hpp
@@ -8,7 +8,7 @@
 
 // Absolute Includes:
 #include "crow/ast/node/fdecl.hpp"
-#include "lib/types.hpp"
+#include "lib/stdtypes.hpp"
 
 namespace codegen {
 // Using Statements:

--- a/src/crow/codegen/llvm_backend/llvm_backend.cpp
+++ b/src/crow/codegen/llvm_backend/llvm_backend.cpp
@@ -21,7 +21,7 @@
 #include "crow/ast/node/include_nodes.hpp"
 #include "crow/debug/log.hpp"
 #include "lib/filesystem.hpp"
-#include "lib/types.hpp"
+#include "lib/stdtypes.hpp"
 
 namespace codegen::llvm_backend {
 // Using Statements:

--- a/src/crow/debug/log.hpp
+++ b/src/crow/debug/log.hpp
@@ -18,7 +18,7 @@ using container::SourcePosition;
 
 // Functions:
 template<typename... Args>
-auto print(Args &&...t_args) -> void
+inline auto print(Args &&...t_args) -> void
 {
   // We use std::clog for logging.
   (std::clog << ... << t_args);
@@ -29,7 +29,7 @@ auto print(Args &&...t_args) -> void
 }
 
 template<typename... Args>
-auto println(Args &&...t_args) -> void
+inline auto println(Args &&...t_args) -> void
 {
   print(std::forward<Args>(t_args)..., '\n');
 }

--- a/src/crow/debug/loglevel.cpp
+++ b/src/crow/debug/loglevel.cpp
@@ -11,7 +11,6 @@ debug::LogLevel g_loglevel{debug::LogLevel::NOTICE};
 
 // Namespace Debug:
 namespace debug {
-[[nodiscard("Returned boolean result must be used.")]]
 auto is_lower_loglevel(const LogLevel t_loglevel) -> bool
 {
   using lib::enum2int;

--- a/src/crow/debug/loglevel.hpp
+++ b/src/crow/debug/loglevel.hpp
@@ -9,7 +9,7 @@
 #include <rang.hpp>
 
 // Absolute Includes:
-#include "lib/types.hpp"
+#include "lib/stdtypes.hpp"
 
 // Macros:
 //! Helper macro for converting @ref LogLevel to string representation.

--- a/src/crow/debug/loglevel.hpp
+++ b/src/crow/debug/loglevel.hpp
@@ -84,6 +84,7 @@ constexpr auto loglevel2color(const LogLevel t_loglevel) -> rang::fg
 /*!
  * Checks if the @ref LogLevel is lower than the current g_loglevel.
  */
+[[nodiscard("Pure function must use return value.")]]
 auto is_lower_loglevel(LogLevel t_loglevel) -> bool;
 
 

--- a/src/crow/parser/pratt/pratt_parser.hpp
+++ b/src/crow/parser/pratt/pratt_parser.hpp
@@ -7,7 +7,7 @@
 
 // Absolute Includes:
 #include "crow/parser/parser.hpp"
-#include "lib/types.hpp"
+#include "lib/stdtypes.hpp"
 
 // Local Includes:
 #include "binding/maps.hpp"

--- a/src/crow/semantic/symbol/symbol_data.cpp
+++ b/src/crow/semantic/symbol/symbol_data.cpp
@@ -52,6 +52,8 @@ auto SymbolData::var() const -> VarTypePtr
 
 auto SymbolData::is_const() const -> bool
 {
+  using lib::Overload;
+
   bool result{false};
 
   const auto var_type{[&](const VarTypePtr& t_data) {
@@ -87,6 +89,8 @@ auto SymbolData::resolve_type() const -> SymbolData
 
 auto SymbolData::native_type() const -> NativeTypeOpt
 {
+  using lib::Overload;
+
   NativeTypeOpt opt;
 
   const auto native{[&](const NativeType t_type) -> NativeTypeOpt {
@@ -106,6 +110,8 @@ auto SymbolData::native_type() const -> NativeTypeOpt
 
 auto SymbolData::type_variant() const -> TypeVariant
 {
+  using lib::Overload;
+
   TypeVariant variant;
 
   const auto native{[&](const NativeType t_type) -> TypeVariant {

--- a/src/lib/CMakeLists.txt
+++ b/src/lib/CMakeLists.txt
@@ -1,4 +1,7 @@
-# Add source files
+# Add source files.
 target_sources(${TARGET_CROW_LIB} PRIVATE
 	filesystem.cpp
 )
+
+# Add subdirectories.
+add_subdirectory(iomanip)

--- a/src/lib/iomanip/CMakeLists.txt
+++ b/src/lib/iomanip/CMakeLists.txt
@@ -1,0 +1,4 @@
+# Add source files.
+target_sources(${TARGET_CROW_LIB} PRIVATE
+	cond_nl.cpp
+)

--- a/src/lib/iomanip/cond_nl.cpp
+++ b/src/lib/iomanip/cond_nl.cpp
@@ -1,0 +1,5 @@
+#include "cond_nl.hpp"
+
+namespace lib::iomanip {
+	
+} // namespace lib::iomanip

--- a/src/lib/iomanip/cond_nl.hpp
+++ b/src/lib/iomanip/cond_nl.hpp
@@ -1,0 +1,20 @@
+#ifndef COND_NL_HPP
+#define COND_NL_HPP
+
+namespace lib::iomanip {
+/*!
+ * Conditional newline insertion class.
+ */
+class CondNl {
+  private:
+  static bool m_insert_nl;
+
+  public:
+  CondNl() = default;
+
+  virtual ~CondNl() = default;
+};
+
+} // namespace lib::iomanip
+
+#endif // COND_NL_HPP

--- a/src/lib/overload.hpp
+++ b/src/lib/overload.hpp
@@ -1,6 +1,7 @@
 #ifndef CROW_LIB_OVERLOAD_HPP
 #define CROW_LIB_OVERLOAD_HPP
 
+namespace lib {
 // Overload pattern:
 /*!
  *	Helper struct for overloading callables when using @ref std::visit.
@@ -13,5 +14,6 @@ struct Overload : Ts... {
 //! Deduction guide for the overload to work.
 template<class... Ts>
 Overload(Ts...) -> Overload<Ts...>;
+} // namespace lib
 
 #endif // CROW_LIB_OVERLOAD_HPP

--- a/src/lib/stdtypes.hpp
+++ b/src/lib/stdtypes.hpp
@@ -1,9 +1,14 @@
-#ifndef CROW_LIB_TYPES_HPP
-#define CROW_LIB_TYPES_HPP
+#ifndef CROW_LIB_STDTYPES_HPP
+#define CROW_LIB_STDTYPES_HPP
 
 // STL Includes:
 #include <cstdint>
 
+/*!
+ * @file
+ *
+ * No namespace for these required, we use these as a default.
+ */
 
 // Aliases:
 // Integer type aliases:
@@ -18,4 +23,4 @@ using i16 = std::int16_t;
 using i32 = std::int32_t;
 using i64 = std::int64_t;
 
-#endif // CROW_LIB_TYPES_HPP
+#endif // CROW_LIB_STDTYPES_HPP


### PR DESCRIPTION
Currently the typing modules are embedded into the ast dir and semantic checking dir.
But it is better to put them into their own toplevel free standing module.