### PR TITLE
Working on attribute implementation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ It is also possible to select for which languages you want interoperability:
 
 Here is a simple sample program.
 ```go
+module main
+
 func main() -> int {
   defer {
     println("Defer!")
@@ -35,6 +37,31 @@ Which can be compiled using:
 ```shell
 crow --backend cpp --interop python samples/hello.cw
 ```
+Which will create an importable Python DLL.
+
+Or here is a simple example using C interop.
+```go
+module main
+
+// Define a forward declaration for the libc abs function.
+[[extern("C")]] {
+  declare func abs(t_x: int) -> int
+}
+
+func main() -> int {
+  let num = abs(-23)
+
+  println("Absolute value of -23 => {}", num)
+
+  return 0
+}
+```
+
+Compile using:
+```shell
+crow --backend cpp samples/attribute.cw
+```
+
 
 This will generate a DLL which can be directly imported from Python.
 

--- a/README.md
+++ b/README.md
@@ -62,7 +62,6 @@ Compile using:
 crow --backend cpp samples/attribute.cw
 ```
 
-
 This will generate a DLL which can be directly imported from Python.
 
 ## Warning

--- a/samples/attribute.cw
+++ b/samples/attribute.cw
@@ -5,7 +5,9 @@ module attribute_module
 }
 
 func main() -> int {
-  abs(-23)
+  let num = abs(-23)
+
+  io::println("Absolute value of -23 => {}", num)
 
   return 0
 }

--- a/samples/attribute.cw
+++ b/samples/attribute.cw
@@ -7,7 +7,7 @@ module attribute_module
 func main() -> int {
   let num = abs(-23)
 
-  io::println("Absolute value of -23 => {}", num)
+  println("Absolute value of -23 => {}", num)
 
   return 0
 }

--- a/samples/attribute.cw
+++ b/samples/attribute.cw
@@ -23,7 +23,7 @@ func test3(t_x: int) -> int {
 
 [[inline]]
 [[constexpr]]
-func test4(t_x: int) -> int {
+func test3(t_x: int) -> int {
   return 30
 }
 

--- a/samples/attribute.cw
+++ b/samples/attribute.cw
@@ -21,6 +21,12 @@ func test3(t_x: int) -> int {
   return 30
 }
 
+[[inline]]
+[[constexpr]]
+func test4(t_x: int) -> int {
+  return 30
+}
+
 func main() -> int {
   let num = abs(-23)
 

--- a/samples/attribute.cw
+++ b/samples/attribute.cw
@@ -1,0 +1,5 @@
+module attribute_module
+
+[[extern("C")]] {
+  declare func abs(t_x: int) -> int
+}

--- a/samples/attribute.cw
+++ b/samples/attribute.cw
@@ -3,3 +3,9 @@ module attribute_module
 [[extern("C")]] {
   declare func abs(t_x: int) -> int
 }
+
+func main() -> int {
+  abs(-23)
+
+  return 0
+}

--- a/samples/attribute.cw
+++ b/samples/attribute.cw
@@ -2,8 +2,4 @@ module attribute_module
 
 [[extern("C")]] {
   declare func abs(t_x: int) -> int
-
-  func abs(t_x: int) -> int {
-    
-  }
 }

--- a/samples/attribute.cw
+++ b/samples/attribute.cw
@@ -2,4 +2,8 @@ module attribute_module
 
 [[extern("C")]] {
   declare func abs(t_x: int) -> int
+
+  func abs(t_x: int) -> int {
+    
+  }
 }

--- a/samples/attribute.cw
+++ b/samples/attribute.cw
@@ -5,6 +5,22 @@ module attribute_module
   declare func abs(t_x: int) -> int
 }
 
+// Inline attribute block.
+[[inline]] {
+  func test1(t_x: int) -> int {
+    return 10
+  }
+
+  func test2(t_x: int) -> int {
+    return 10
+  }
+}
+
+[[inline]]
+func test3(t_x: int) -> int {
+  return 30
+}
+
 func main() -> int {
   let num = abs(-23)
 

--- a/samples/attribute.cw
+++ b/samples/attribute.cw
@@ -1,5 +1,6 @@
 module attribute_module
 
+// Define a forward declaration for the libc abs function.
 [[extern("C")]] {
   declare func abs(t_x: int) -> int
 }

--- a/src/crow/ast/node/function/function.hpp
+++ b/src/crow/ast/node/function/function.hpp
@@ -9,6 +9,7 @@
 
 namespace ast::node::function {
 // Using Statements:
+using node_traits::AttributeData;
 using node_traits::Body;
 using node_traits::Identifier;
 using node_traits::Params;
@@ -20,7 +21,8 @@ class Function : public Identifier,
                  public Params,
                  public TypeAnnotation,
                  public Body,
-                 public TypeData {
+                 public TypeData,
+                 public AttributeData {
   public:
   Function(std::string_view t_identifier, NodeListPtr&& t_params,
            std::string_view t_type, NodeListPtr&& t_body);

--- a/src/crow/ast/node/meta/CMakeLists.txt
+++ b/src/crow/ast/node/meta/CMakeLists.txt
@@ -3,4 +3,5 @@ target_sources(${TARGET_CROW_LIB} PRIVATE
 	function_decl.cpp
 	let_decl.cpp
 	var_decl.cpp
+	attribute.cpp
 )

--- a/src/crow/ast/node/meta/attribute.cpp
+++ b/src/crow/ast/node/meta/attribute.cpp
@@ -1,0 +1,11 @@
+#include "attribute.hpp"
+
+namespace ast::node::meta {
+// Methods:
+Attribute::Attribute(const std::string_view t_identifier,
+                     NodeListPtr&& t_params, NodeListPtr&& t_body)
+  : Identifier{t_identifier},
+    Params{std::move(t_params)},
+    Body{std::move(t_body)}
+{}
+} // namespace ast::node::meta

--- a/src/crow/ast/node/meta/attribute.hpp
+++ b/src/crow/ast/node/meta/attribute.hpp
@@ -1,0 +1,32 @@
+#ifndef ATTRIBUTE_HPP
+#define ATTRIBUTE_HPP
+
+// Relative Includes:
+#include "../node_traits/include.hpp"
+
+// Local Includes:
+#include "fdecl.hpp"
+
+namespace ast::node::meta {
+// Using:
+using node_traits::Body;
+using node_traits::Identifier;
+using node_traits::Params;
+
+// Classes:
+class Attribute : public Identifier, public Params, public Body {
+  public:
+  Attribute(std::string_view t_identifier, NodeListPtr&& t_params,
+            NodeListPtr&& t_body);
+
+  AST_ARCHIVE_MAKE_TRAITS_ARCHIVEABLE(Attribute, Identifier, Params)
+  AST_VISITOR_MAKE_VISITABLE(visitor::NodeVisitor);
+
+  virtual ~Attribute() = default;
+};
+} // namespace ast::node::meta
+
+// Cereal type registration:
+REGISTER_ARCHIVEABLE_TYPE(ast::node::meta, Attribute);
+
+#endif // ATTRIBUTE_HPP

--- a/src/crow/ast/node/meta/attribute.hpp
+++ b/src/crow/ast/node/meta/attribute.hpp
@@ -9,12 +9,13 @@
 
 namespace ast::node::meta {
 // Using:
+using node_traits::AttributeData;
 using node_traits::Body;
 using node_traits::Identifier;
 using node_traits::Params;
 
 // Classes:
-class Attribute : public Identifier, public Params, public Body {
+class Attribute : public Identifier, public Params, public Body, AttributeData {
   public:
   Attribute(std::string_view t_identifier, NodeListPtr&& t_params,
             NodeListPtr&& t_body);

--- a/src/crow/ast/node/meta/attribute.hpp
+++ b/src/crow/ast/node/meta/attribute.hpp
@@ -15,7 +15,10 @@ using node_traits::Identifier;
 using node_traits::Params;
 
 // Classes:
-class Attribute : public Identifier, public Params, public Body, AttributeData {
+class Attribute : public Identifier,
+                  public Params,
+                  public Body,
+                  public AttributeData {
   public:
   Attribute(std::string_view t_identifier, NodeListPtr&& t_params,
             NodeListPtr&& t_body);

--- a/src/crow/ast/node/meta/attribute.hpp
+++ b/src/crow/ast/node/meta/attribute.hpp
@@ -1,5 +1,5 @@
-#ifndef ATTRIBUTE_HPP
-#define ATTRIBUTE_HPP
+#ifndef CROW_CROW_AST_NODE_META_ATTRIBUTE_HPP
+#define CROW_CROW_AST_NODE_META_ATTRIBUTE_HPP
 
 // Relative Includes:
 #include "../node_traits/include.hpp"
@@ -29,4 +29,4 @@ class Attribute : public Identifier, public Params, public Body {
 // Cereal type registration:
 REGISTER_ARCHIVEABLE_TYPE(ast::node::meta, Attribute);
 
-#endif // ATTRIBUTE_HPP
+#endif // CROW_CROW_AST_NODE_META_ATTRIBUTE_HPP

--- a/src/crow/ast/node/meta/fdecl.hpp
+++ b/src/crow/ast/node/meta/fdecl.hpp
@@ -6,6 +6,8 @@ namespace ast::node::meta {
 class FunctionDecl;
 class LetDecl;
 class VarDecl;
+
+class Attribute;
 } // namespace ast::node::meta
 
 #endif // CROW_CROW_AST_NODE_META_FDECL_HPP

--- a/src/crow/ast/node/meta/function_decl.hpp
+++ b/src/crow/ast/node/meta/function_decl.hpp
@@ -9,6 +9,7 @@
 
 namespace ast::node::meta {
 // Using:
+using node_traits::AttributeData;
 using node_traits::Identifier;
 using node_traits::Params;
 using node_traits::TypeAnnotation;
@@ -18,7 +19,8 @@ using node_traits::TypeData;
 class FunctionDecl : public Identifier,
                      public Params,
                      public TypeAnnotation,
-                     public TypeData {
+                     public TypeData,
+                     public AttributeData {
   public:
   FunctionDecl(std::string_view t_identifier, NodeListPtr&& t_params,
                std::string_view t_type);

--- a/src/crow/ast/node/meta/function_decl.hpp
+++ b/src/crow/ast/node/meta/function_decl.hpp
@@ -8,7 +8,7 @@
 #include "fdecl.hpp"
 
 namespace ast::node::meta {
-// Using Statements:
+// Using:
 using node_traits::Identifier;
 using node_traits::Params;
 using node_traits::TypeAnnotation;

--- a/src/crow/ast/node/meta/include.hpp
+++ b/src/crow/ast/node/meta/include.hpp
@@ -2,6 +2,7 @@
 #define CROW_CROW_AST_NODE_META_INCLUDE_HPP
 
 // Meta:
+#include "attribute.hpp"
 #include "function_decl.hpp"
 #include "let_decl.hpp"
 #include "var_decl.hpp"

--- a/src/crow/ast/node/meta/let_decl.hpp
+++ b/src/crow/ast/node/meta/let_decl.hpp
@@ -9,12 +9,16 @@
 
 namespace ast::node::meta {
 // Using Statements:
+using node_traits::AttributeData;
 using node_traits::Identifier;
 using node_traits::TypeAnnotation;
 using node_traits::TypeData;
 
 // Classes:
-class LetDecl : public Identifier, public TypeAnnotation, public TypeData {
+class LetDecl : public Identifier,
+                public TypeAnnotation,
+                public TypeData,
+                public AttributeData {
   public:
   LetDecl(std::string_view t_identifier, std::string_view t_type);
 

--- a/src/crow/ast/node/meta/var_decl.hpp
+++ b/src/crow/ast/node/meta/var_decl.hpp
@@ -9,12 +9,16 @@
 
 namespace ast::node::meta {
 // Using Statements:
+using node_traits::AttributeData;
 using node_traits::Identifier;
 using node_traits::TypeAnnotation;
 using node_traits::TypeData;
 
 // Classes:
-class VarDecl : public Identifier, public TypeAnnotation, public TypeData {
+class VarDecl : public Identifier,
+                public TypeAnnotation,
+                public TypeData,
+                public AttributeData {
   public:
   VarDecl(std::string_view t_identifier, std::string_view t_type);
 

--- a/src/crow/ast/node/node_traits/CMakeLists.txt
+++ b/src/crow/ast/node/node_traits/CMakeLists.txt
@@ -15,4 +15,5 @@ target_sources(${TARGET_CROW_LIB} PRIVATE
 	unary_operator.cpp
 	binary_operator.cpp
 	type_data.cpp
+	attribute_data.cpp
 )

--- a/src/crow/ast/node/node_traits/attribute_data.cpp
+++ b/src/crow/ast/node/node_traits/attribute_data.cpp
@@ -128,9 +128,7 @@ auto operator<<(std::ostream& t_os,
                 const ast::node::node_traits::AttributeSeq& t_seq)
   -> std::ostream&
 {
-  using namespace lib::stdprint::vector;
+  using lib::stdprint::detail::print_seq;
 
-  t_os << t_seq;
-
-  return t_os;
+  return print_seq(t_os, t_seq);
 }

--- a/src/crow/ast/node/node_traits/attribute_data.cpp
+++ b/src/crow/ast/node/node_traits/attribute_data.cpp
@@ -1,0 +1,5 @@
+#include "attribute_data.hpp"
+
+namespace ast::node::node_traits {
+// Methods:
+} // namespace ast::node::node_traits

--- a/src/crow/ast/node/node_traits/attribute_data.cpp
+++ b/src/crow/ast/node/node_traits/attribute_data.cpp
@@ -1,5 +1,8 @@
 #include "attribute_data.hpp"
 
+// STL Includes:
+#include <iomanip>
+
 // Absolute Includes:
 #include "lib/stdexcept/stdexcept.hpp"
 
@@ -105,7 +108,7 @@ auto operator<<(std::ostream& t_os,
 {
   const auto& [type, id, args] = t_data;
 
-  t_os << type << ":" << id;
+  t_os << "(" << type << ":" << std::quoted(id) << ")";
 
   return t_os;
 }

--- a/src/crow/ast/node/node_traits/attribute_data.cpp
+++ b/src/crow/ast/node/node_traits/attribute_data.cpp
@@ -13,9 +13,19 @@
     break
 
 namespace ast::node::node_traits {
+AttributeMetadata::AttributeMetadata()
+  : m_type{AttributeType::NO_ATTRIBUTE}, m_identifier{}, m_args{}
+{}
+
+AttributeMetadata::AttributeMetadata(const std::string_view t_identifier,
+                                     AttributeArgs&& t_args)
+  : m_type{str2attribute_type(t_identifier)},
+    m_identifier{std::string{t_identifier}},
+    m_args{std::move(t_args)}
+{}
+
 // Methods:
-AttributeData::AttributeData()
-  : m_attr{AttributeType::NO_ATTRIBUTE, std::string{}, AttributeArgs{}}
+AttributeData::AttributeData(): m_attr{std::string{}, AttributeArgs{}}
 {}
 
 auto AttributeData::set_attribute(const AttributeMetadata& t_attr) -> void
@@ -24,11 +34,11 @@ auto AttributeData::set_attribute(const AttributeMetadata& t_attr) -> void
 }
 
 auto AttributeData::set_attribute(std::string_view t_identifier,
-                                  const AttributeArgs& t_args) -> void
+                                  AttributeArgs&& t_args) -> void
 {
   const auto type{str2attribute_type(t_identifier)};
 
-  m_attr = {type, std::string{t_identifier}, t_args};
+  m_attr = AttributeMetadata{t_identifier, std::move(t_args)};
 }
 
 auto AttributeData::get_attribute() const -> const AttributeMetadata&

--- a/src/crow/ast/node/node_traits/attribute_data.cpp
+++ b/src/crow/ast/node/node_traits/attribute_data.cpp
@@ -34,7 +34,7 @@ auto AttributeData::set_attribute(const AttributeMetadata& t_attr) -> void
 }
 
 auto AttributeData::set_attribute(std::string_view t_identifier,
-                                  AttributeArgs&& t_args) -> void
+                                  AttributeArgs t_args) -> void
 {
   const auto type{str2attribute_type(t_identifier)};
 

--- a/src/crow/ast/node/node_traits/attribute_data.cpp
+++ b/src/crow/ast/node/node_traits/attribute_data.cpp
@@ -2,4 +2,55 @@
 
 namespace ast::node::node_traits {
 // Methods:
+AttributeData::AttributeData()
+  : m_attr{AttributeType::NO_ATTRIBUTE, std::string{}, AttributeArgs{}}
+{}
+
+auto AttributeData::set_attribute(const AttributeMetadata& t_attr) -> void
+{
+  m_attr = t_attr;
+}
+
+auto AttributeData::set_attribute(std::string_view t_identifier,
+                                  const AttributeArgs& t_args) -> void
+{
+  const auto type{str2attribute_type(t_identifier)};
+
+  m_attr = {type, std::string{t_identifier}, t_args};
+}
+
+auto AttributeData::get_attribute() const -> const AttributeMetadata&
+{
+  return m_attr;
+}
+
+auto AttributeData::is_attribute_set() -> bool
+{
+  return (m_attr.m_type != AttributeType::NO_ATTRIBUTE);
+}
+
+// Functions:
+auto str2attribute_type(std::string_view t_str) -> AttributeType
+{
+  auto type{AttributeType::NO_ATTRIBUTE};
+
+  if(t_str.empty()) {
+    // An empty string means no attribute is provided.
+    return type;
+  }
+
+  // Builtin attributes:
+  if(t_str == "inline") {
+    type = AttributeType::INLINE;
+  } else if(t_str == "deprecated") {
+    type = AttributeType::DEPRECATED;
+  } else if(t_str == "extern") {
+    type = AttributeType::EXTERN;
+  } else {
+    // If we dont recognize, any of the builtin types
+    type = AttributeType::UNKNOWN;
+  }
+
+  return type;
+}
 } // namespace ast::node::node_traits

--- a/src/crow/ast/node/node_traits/attribute_data.cpp
+++ b/src/crow/ast/node/node_traits/attribute_data.cpp
@@ -1,5 +1,14 @@
 #include "attribute_data.hpp"
 
+// Absolute Includes:
+#include "lib/stdexcept/stdexcept.hpp"
+
+// Macros:
+#define MATCH(t_key, t_value) \
+  case AttributeType::t_key:  \
+    str = t_value;            \
+    break
+
 namespace ast::node::node_traits {
 // Methods:
 AttributeData::AttributeData()
@@ -30,6 +39,29 @@ auto AttributeData::is_attribute_set() -> bool
 }
 
 // Functions:
+auto attribute_type2str(AttributeType t_type) -> std::string_view
+{
+  std::string_view str{};
+
+  switch(t_type) {
+    MATCH(NO_ATTRIBUTE, "no_attribute");
+    MATCH(INLINE, "inline");
+    MATCH(DEPRECATED, "deprecated");
+    MATCH(EXTERN, "extern");
+    MATCH(UNKNOWN, "unknown");
+
+    default: {
+      using lib::stdexcept::throw_invalid_argument;
+
+      throw_invalid_argument(
+        "Unhandled AttributeType cant be converted to string.");
+      break;
+    }
+  }
+
+  return str;
+}
+
 auto str2attribute_type(std::string_view t_str) -> AttributeType
 {
   auto type{AttributeType::NO_ATTRIBUTE};
@@ -54,3 +86,26 @@ auto str2attribute_type(std::string_view t_str) -> AttributeType
   return type;
 }
 } // namespace ast::node::node_traits
+
+// Functions:
+auto operator<<(std::ostream& t_os,
+                const ast::node::node_traits::AttributeType t_type)
+  -> std::ostream&
+{
+  using ast::node::node_traits::attribute_type2str;
+
+  t_os << attribute_type2str(t_type);
+
+  return t_os;
+}
+
+auto operator<<(std::ostream& t_os,
+                const ast::node::node_traits::AttributeMetadata& t_data)
+  -> std::ostream&
+{
+  const auto& [type, id, args] = t_data;
+
+  t_os << type << ":" << id;
+
+  return t_os;
+}

--- a/src/crow/ast/node/node_traits/attribute_data.cpp
+++ b/src/crow/ast/node/node_traits/attribute_data.cpp
@@ -5,6 +5,7 @@
 
 // Absolute Includes:
 #include "lib/stdexcept/stdexcept.hpp"
+#include "lib/stdprint.hpp"
 
 // Macros:
 #define MATCH(t_key, t_value) \
@@ -25,30 +26,30 @@ AttributeMetadata::AttributeMetadata(const std::string_view t_identifier,
 {}
 
 // Methods:
-AttributeData::AttributeData(): m_attr{std::string{}, AttributeArgs{}}
+AttributeData::AttributeData(): m_attr_seq{}
 {}
 
-auto AttributeData::set_attribute(const AttributeMetadata& t_attr) -> void
+auto AttributeData::add_attribute(const AttributeMetadata& t_attr) -> void
 {
-  m_attr = t_attr;
+  m_attr_seq.push_back(t_attr);
 }
 
-auto AttributeData::set_attribute(std::string_view t_identifier,
+auto AttributeData::add_attribute(std::string_view t_identifier,
                                   AttributeArgs t_args) -> void
 {
-  const auto type{str2attribute_type(t_identifier)};
+  AttributeMetadata attr{t_identifier, std::move(t_args)};
 
-  m_attr = AttributeMetadata{t_identifier, std::move(t_args)};
+  m_attr_seq.push_back(std::move(attr));
 }
 
-auto AttributeData::get_attribute() const -> const AttributeMetadata&
+auto AttributeData::get_attributes() const -> const AttributeSeq&
 {
-  return m_attr;
+  return m_attr_seq;
 }
 
-auto AttributeData::is_attribute_set() -> bool
+auto AttributeData::no_attributes() const -> bool
 {
-  return (m_attr.m_type != AttributeType::NO_ATTRIBUTE);
+  return m_attr_seq.empty();
 }
 
 // Functions:
@@ -119,6 +120,17 @@ auto operator<<(std::ostream& t_os,
   const auto& [type, id, args] = t_data;
 
   t_os << "(" << type << ":" << std::quoted(id) << ")";
+
+  return t_os;
+}
+
+auto operator<<(std::ostream& t_os,
+                const ast::node::node_traits::AttributeSeq& t_seq)
+  -> std::ostream&
+{
+  using namespace lib::stdprint::vector;
+
+  t_os << t_seq;
 
   return t_os;
 }

--- a/src/crow/ast/node/node_traits/attribute_data.hpp
+++ b/src/crow/ast/node/node_traits/attribute_data.hpp
@@ -40,6 +40,12 @@ struct AttributeMetadata {
   // Raw data.
   std::string m_identifier;
   AttributeArgs m_args;
+
+  AttributeMetadata();
+  explicit AttributeMetadata(std::string_view t_identifier,
+                             AttributeArgs&& t_args);
+
+  virtual ~AttributeMetadata() = default;
 };
 
 // Classes:

--- a/src/crow/ast/node/node_traits/attribute_data.hpp
+++ b/src/crow/ast/node/node_traits/attribute_data.hpp
@@ -4,6 +4,7 @@
 // STL Include:
 #include <string>
 #include <string_view>
+#include <vector>
 
 // Absolute Includes:
 #include "crow/ast/node/node_interface.hpp"
@@ -12,11 +13,33 @@
 #include "fdecl.hpp"
 
 namespace ast::node::node_traits {
+// Aliases:
+using AttributeArgs = std::vector<std::string>;
+
+// Enums:
+enum class AttributeType {
+  NO_ATTRIBUTE, //!< If no attribute is given.
+
+  // Common builtin
+  INLINE,
+  DEPRECATED,
+  EXTERN,
+
+  UNKNOWN //!< Reserved for third party attributes.
+};
+
 // Structs:
-// struct AttributeSpec {
-//   std::string t_identifier;
-//   TODO:
-// };
+/*!
+ * Holds the metadata which we annotate the AST with.
+ */
+struct AttributeMetadata {
+  //! Determines what behavior should be classified.
+  AttributeType m_type;
+
+  // Raw data.
+  std::string m_identifier;
+  AttributeArgs m_args;
+};
 
 // Classes:
 /*!
@@ -25,11 +48,19 @@ namespace ast::node::node_traits {
  * When generating code, or translating to IR.
  */
 class AttributeData : virtual public NodeInterface {
-  public:
-  AttributeData() = default;
+  private:
+  AttributeMetadata m_attr;
 
-  // virtual auto set_attribute() -> void;
-  // virtual auto get_attribute() const -> const TypeVariant&;
+  public:
+  AttributeData();
+
+  virtual auto set_attribute(const AttributeMetadata&) -> void;
+  virtual auto set_attribute(std::string_view t_identifier,
+                             const AttributeArgs& t_args) -> void;
+
+  virtual auto get_attribute() const -> const AttributeMetadata&;
+
+  virtual auto is_attribute_set() -> bool;
 
   // AST_ARCHIVE_MAKE_ARCHIVEABLE(AttributeData)
   // {
@@ -40,6 +71,9 @@ class AttributeData : virtual public NodeInterface {
 
   virtual ~AttributeData() = default;
 };
+
+// Functions:
+auto str2attribute_type(std::string_view t_str) -> AttributeType;
 } // namespace ast::node::node_traits
 
 // Cereal register type:

--- a/src/crow/ast/node/node_traits/attribute_data.hpp
+++ b/src/crow/ast/node/node_traits/attribute_data.hpp
@@ -1,0 +1,48 @@
+#ifndef ATTRIBUTE_DATA_HPP
+#define ATTRIBUTE_DATA_HPP
+
+// STL Include:
+#include <string>
+#include <string_view>
+
+// Absolute Includes:
+#include "crow/ast/node/node_interface.hpp"
+
+// Local Includes:
+#include "fdecl.hpp"
+
+namespace ast::node::node_traits {
+// Structs:
+// struct AttributeSpec {
+//   std::string t_identifier;
+//   TODO:
+// };
+
+// Classes:
+/*!
+ * Class for annotating the AST with attribute information.
+ * This is necessary, for when need the attribute information on hand.
+ * When generating code, or translating to IR.
+ */
+class AttributeData : virtual public NodeInterface {
+  public:
+  AttributeData() = default;
+
+  // virtual auto set_attribute() -> void;
+  // virtual auto get_attribute() const -> const TypeVariant&;
+
+  // AST_ARCHIVE_MAKE_ARCHIVEABLE(AttributeData)
+  // {
+  //   t_archive(CEREAL_NVP(m_args));
+  // }
+
+  AST_VISITOR_VISITABLE_PURE_ACCEPT(visitor::NodeVisitor);
+
+  virtual ~AttributeData() = default;
+};
+} // namespace ast::node::node_traits
+
+// Cereal register type:
+// REGISTER_ARCHIVEABLE_TYPE(ast::node::node_traits, AttributeData);
+
+#endif // ATTRIBUTE_DATA_HPP

--- a/src/crow/ast/node/node_traits/attribute_data.hpp
+++ b/src/crow/ast/node/node_traits/attribute_data.hpp
@@ -63,7 +63,7 @@ class AttributeData : virtual public NodeInterface {
 
   virtual auto set_attribute(const AttributeMetadata&) -> void;
   virtual auto set_attribute(std::string_view t_identifier,
-                             const AttributeArgs& t_args) -> void;
+                             AttributeArgs t_args) -> void;
 
   virtual auto get_attribute() const -> const AttributeMetadata&;
 

--- a/src/crow/ast/node/node_traits/attribute_data.hpp
+++ b/src/crow/ast/node/node_traits/attribute_data.hpp
@@ -14,8 +14,12 @@
 #include "fdecl.hpp"
 
 namespace ast::node::node_traits {
+// Forward Declarations:
+struct AttributeMetadata;
+
 // Aliases:
 using AttributeArgs = std::vector<std::string>;
+using AttributeSeq = std::vector<AttributeMetadata>;
 
 // Enums:
 enum class AttributeType {
@@ -56,18 +60,17 @@ struct AttributeMetadata {
  */
 class AttributeData : virtual public NodeInterface {
   private:
-  AttributeMetadata m_attr;
+  AttributeSeq m_attr_seq;
 
   public:
   AttributeData();
 
-  virtual auto set_attribute(const AttributeMetadata&) -> void;
-  virtual auto set_attribute(std::string_view t_identifier,
+  virtual auto add_attribute(const AttributeMetadata&) -> void;
+  virtual auto add_attribute(std::string_view t_identifier,
                              AttributeArgs t_args) -> void;
 
-  virtual auto get_attribute() const -> const AttributeMetadata&;
-
-  virtual auto is_attribute_set() -> bool;
+  virtual auto get_attributes() const -> const AttributeSeq&;
+  virtual auto no_attributes() const -> bool;
 
   // AST_ARCHIVE_MAKE_ARCHIVEABLE(AttributeData)
   // {
@@ -89,6 +92,9 @@ auto operator<<(std::ostream& t_os,
                 ast::node::node_traits::AttributeType t_type) -> std::ostream&;
 auto operator<<(std::ostream& t_os,
                 const ast::node::node_traits::AttributeMetadata& t_type)
+  -> std::ostream&;
+auto operator<<(std::ostream& t_os,
+                const ast::node::node_traits::AttributeSeq& t_seq)
   -> std::ostream&;
 
 // Cereal register type:

--- a/src/crow/ast/node/node_traits/attribute_data.hpp
+++ b/src/crow/ast/node/node_traits/attribute_data.hpp
@@ -1,5 +1,5 @@
-#ifndef ATTRIBUTE_DATA_HPP
-#define ATTRIBUTE_DATA_HPP
+#ifndef CROW_CROW_AST_NODE_NODE_TRAITS_ATTRIBUTE_DATA_HPP
+#define CROW_CROW_AST_NODE_NODE_TRAITS_ATTRIBUTE_DATA_HPP
 
 // STL Include:
 #include <string>
@@ -45,4 +45,4 @@ class AttributeData : virtual public NodeInterface {
 // Cereal register type:
 // REGISTER_ARCHIVEABLE_TYPE(ast::node::node_traits, AttributeData);
 
-#endif // ATTRIBUTE_DATA_HPP
+#endif // CROW_CROW_AST_NODE_NODE_TRAITS_ATTRIBUTE_DATA_HPP

--- a/src/crow/ast/node/node_traits/attribute_data.hpp
+++ b/src/crow/ast/node/node_traits/attribute_data.hpp
@@ -2,6 +2,7 @@
 #define CROW_CROW_AST_NODE_NODE_TRAITS_ATTRIBUTE_DATA_HPP
 
 // STL Include:
+#include <iosfwd>
 #include <string>
 #include <string_view>
 #include <vector>
@@ -73,8 +74,16 @@ class AttributeData : virtual public NodeInterface {
 };
 
 // Functions:
+auto attribute_type2str(AttributeType t_type) -> std::string_view;
 auto str2attribute_type(std::string_view t_str) -> AttributeType;
 } // namespace ast::node::node_traits
+
+// Functions:
+auto operator<<(std::ostream& t_os,
+                ast::node::node_traits::AttributeType t_type) -> std::ostream&;
+auto operator<<(std::ostream& t_os,
+                const ast::node::node_traits::AttributeMetadata& t_type)
+  -> std::ostream&;
 
 // Cereal register type:
 // REGISTER_ARCHIVEABLE_TYPE(ast::node::node_traits, AttributeData);

--- a/src/crow/ast/node/node_traits/decl_expr.hpp
+++ b/src/crow/ast/node/node_traits/decl_expr.hpp
@@ -1,18 +1,17 @@
 #ifndef CROW_CROW_AST_NODE_NODE_TRAITS_DECL_EXPR_HPP
 #define CROW_CROW_AST_NODE_NODE_TRAITS_DECL_EXPR_HPP
 
-// Absolute Includes:
-#include "crow/ast/node/node_traits/type_data.hpp"
-
 // Includes:
 #include "../include.hpp"
 
 // Local Includes:
+#include "attribute_data.hpp"
 #include "fdecl.hpp"
 #include "identifier.hpp"
 #include "init_expr.hpp"
 #include "node_position.hpp"
 #include "type_annotation.hpp"
+#include "type_data.hpp"
 
 namespace ast::node::node_traits {
 // Using Statements:
@@ -23,6 +22,7 @@ class DeclExpr : public NodePosition,
                  public Identifier,
                  public TypeAnnotation,
                  public TypeData,
+                 public AttributeData,
                  public InitExpr {
   public:
   DeclExpr(TextPosition&& t_pos, std::string_view t_identifier,

--- a/src/crow/ast/node/node_traits/fdecl.hpp
+++ b/src/crow/ast/node/node_traits/fdecl.hpp
@@ -18,6 +18,7 @@ class Alt;
 class UnaryOperator;
 class BinaryOperator;
 class TypeData;
+class AttributeData;
 
 template<typename T>
 class Op;

--- a/src/crow/ast/node/node_traits/include.hpp
+++ b/src/crow/ast/node/node_traits/include.hpp
@@ -4,6 +4,7 @@
 // Node traits:
 #include "alt.hpp"
 #include "args.hpp"
+#include "attribute_data.hpp"
 #include "binary_operator.hpp"
 #include "body.hpp"
 #include "condition.hpp"

--- a/src/crow/ast/node/node_traits/type_data.hpp
+++ b/src/crow/ast/node/node_traits/type_data.hpp
@@ -26,10 +26,20 @@ class TypeData : virtual public NodeInterface {
   virtual auto set_type(TypeVariant t_data) -> void;
   virtual auto get_type() const -> const TypeVariant&;
 
+	// TODO: Fix serialization.
+  // AST_ARCHIVE_MAKE_ARCHIVEABLE(TypeData)
+  // {
+  //    t_archive(CEREAL_NVP(m_data));
+  // }
+
   AST_VISITOR_VISITABLE_PURE_ACCEPT(visitor::NodeVisitor);
 
   virtual ~TypeData() = default;
 };
 } // namespace ast::node::node_traits
+
+// Cereal register type:
+// REGISTER_ARCHIVEABLE_TYPE(ast::node::node_traits, TypeData);
+
 
 #endif // CROW_CROW_AST_NODE_NODE_TRAITS_TYPE_DATA_HPP

--- a/src/crow/ast/node/node_traits/type_data.hpp
+++ b/src/crow/ast/node/node_traits/type_data.hpp
@@ -26,7 +26,7 @@ class TypeData : virtual public NodeInterface {
   virtual auto set_type(TypeVariant t_data) -> void;
   virtual auto get_type() const -> const TypeVariant&;
 
-	// TODO: Fix serialization.
+  // TODO: Fix serialization.
   // AST_ARCHIVE_MAKE_ARCHIVEABLE(TypeData)
   // {
   //    t_archive(CEREAL_NVP(m_data));

--- a/src/crow/ast/visitor/ast_archive.cpp
+++ b/src/crow/ast/visitor/ast_archive.cpp
@@ -104,9 +104,20 @@ DEFINE_SERIALIZE_METHOD(Var);
 DEFINE_SERIALIZE_METHOD(Variable);
 
 // Meta:
-DEFINE_SERIALIZE_METHOD(FunctionDecl);
+auto AstArchive::visit([[maybe_unused]] Attribute* t_attr) -> Any
+{
+  // archive(*t_ptr);
+
+  // TODO: Implement.
+  RUNTIME_ERROR("Attribute node not supported for serialization yet.");
+
+  return {};
+}
+
+// DEFINE_SERIALIZE_METHOD(Attribute);
 DEFINE_SERIALIZE_METHOD(LetDecl);
 DEFINE_SERIALIZE_METHOD(VarDecl);
+DEFINE_SERIALIZE_METHOD(FunctionDecl);
 
 // Operators:
 DEFINE_SERIALIZE_METHOD(Arithmetic);

--- a/src/crow/ast/visitor/ast_archive.hpp
+++ b/src/crow/ast/visitor/ast_archive.hpp
@@ -106,9 +106,10 @@ class AstArchive : public NodeVisitor {
   auto visit(node::lvalue::Variable* t_var) -> Any override;
 
   // Meta:
-  auto visit(node::meta::FunctionDecl* t_fdecl) -> Any override;
+  auto visit(node::meta::Attribute* t_attr) -> Any override;
   auto visit(node::meta::LetDecl* t_ldecl) -> Any override;
   auto visit(node::meta::VarDecl* t_vdecl) -> Any override;
+  auto visit(node::meta::FunctionDecl* t_fdecl) -> Any override;
 
   // Operators:
   auto visit(node::operators::Arithmetic* t_arith) -> Any override;

--- a/src/crow/ast/visitor/ast_printer.cpp
+++ b/src/crow/ast/visitor/ast_printer.cpp
@@ -108,12 +108,12 @@ auto AstPrinter::visit(Variable* t_var) -> Any
 }
 
 // Meta:
-auto AstPrinter::visit(FunctionDecl* t_fdecl) -> Any
+auto AstPrinter::visit(Attribute* t_attr) -> Any
 {
   COUNTG_INIT();
 
-  print("FunctionDecl: ", t_fdecl->identifier());
-  print_traits(t_fdecl);
+  print("Attribute: ", t_attr->identifier());
+  print_traits(t_attr);
 
   return {};
 }
@@ -134,6 +134,16 @@ auto AstPrinter::visit(VarDecl* t_vdecl) -> Any
 
   print("VarDecl: ", t_vdecl->identifier());
   print_traits(t_vdecl);
+
+  return {};
+}
+
+auto AstPrinter::visit(FunctionDecl* t_fdecl) -> Any
+{
+  COUNTG_INIT();
+
+  print("FunctionDecl: ", t_fdecl->identifier());
+  print_traits(t_fdecl);
 
   return {};
 }

--- a/src/crow/ast/visitor/ast_printer.hpp
+++ b/src/crow/ast/visitor/ast_printer.hpp
@@ -110,7 +110,7 @@ class AstPrinter : public NodeVisitor {
     });
 
     when_derived<AttributeData>(t_ptr, [&](auto t_ptr) {
-      print("| Attribute Data: ", t_ptr->get_attribute());
+      print("| Attribute Data: ", t_ptr->get_attributes());
     });
 
     when_derived<Body>(t_ptr, [&](auto t_ptr) {

--- a/src/crow/ast/visitor/ast_printer.hpp
+++ b/src/crow/ast/visitor/ast_printer.hpp
@@ -153,9 +153,10 @@ class AstPrinter : public NodeVisitor {
   auto visit(node::lvalue::Variable* t_var) -> Any override;
 
   // Meta:
-  auto visit(node::meta::FunctionDecl* t_fdecl) -> Any override;
+  auto visit(node::meta::Attribute* t_attr) -> Any override;
   auto visit(node::meta::LetDecl* t_ldecl) -> Any override;
   auto visit(node::meta::VarDecl* t_vdecl) -> Any override;
+  auto visit(node::meta::FunctionDecl* t_fdecl) -> Any override;
 
   // Operators:
   auto visit(node::operators::Arithmetic* t_arith) -> Any override;

--- a/src/crow/ast/visitor/ast_printer.hpp
+++ b/src/crow/ast/visitor/ast_printer.hpp
@@ -109,6 +109,10 @@ class AstPrinter : public NodeVisitor {
       print("| Type Data: ", t_ptr->get_type());
     });
 
+    when_derived<AttributeData>(t_ptr, [&](auto t_ptr) {
+      print("| Attribute Data: ", t_ptr->get_attribute());
+    });
+
     when_derived<Body>(t_ptr, [&](auto t_ptr) {
       lambda("Body", t_ptr->body());
     });

--- a/src/crow/ast/visitor/node_visitor.cpp
+++ b/src/crow/ast/visitor/node_visitor.cpp
@@ -62,6 +62,7 @@ STUB(Var)
 STUB(Variable)
 
 // Meta:
+STUB(Attribute)
 STUB(LetDecl)
 STUB(VarDecl)
 STUB(FunctionDecl)

--- a/src/crow/ast/visitor/node_visitor.cpp
+++ b/src/crow/ast/visitor/node_visitor.cpp
@@ -6,6 +6,7 @@
 // Absolute Includes:
 #include "crow/ast/node/include_nodes.hpp"
 #include "crow/debug/log.hpp"
+#include "lib/check_nullptr.hpp"
 #include "lib/stdexcept/stdexcept.hpp"
 
 
@@ -31,12 +32,8 @@ auto NodeVisitor::traverse(NodePtr t_node) -> Any
 {
   Any any{};
 
-  // Throw on nullptr.
-  if(!t_node) {
-    using lib::stdexcept::throw_unexpected_nullptr;
-
-    throw_unexpected_nullptr("Cant traverse a nullptr.");
-  }
+  // We cant traverse a nullptr.
+  CHECK_NULLPTR(t_node);
 
   // Kick off the traversal.
   any = t_node->accept(this);

--- a/src/crow/ast/visitor/node_visitor.hpp
+++ b/src/crow/ast/visitor/node_visitor.hpp
@@ -57,9 +57,10 @@ class NodeVisitor {
   virtual auto visit(node::lvalue::Variable* t_var) -> Any;
 
   // Meta:
-  virtual auto visit(node::meta::FunctionDecl* t_fdecl) -> Any;
+  virtual auto visit(node::meta::Attribute* t_attr) -> Any;
   virtual auto visit(node::meta::LetDecl* t_ldecl) -> Any;
   virtual auto visit(node::meta::VarDecl* t_vdecl) -> Any;
+  virtual auto visit(node::meta::FunctionDecl* t_fdecl) -> Any;
 
   // Operators:
   virtual auto visit(node::operators::Arithmetic* t_arith) -> Any;

--- a/src/crow/codegen/cpp_backend/cpp_backend.cpp
+++ b/src/crow/codegen/cpp_backend/cpp_backend.cpp
@@ -333,7 +333,7 @@ auto CppBackend::visit(Attribute* t_attr) -> Any
   switch(attr_type) {
     case AttributeType::EXTERN:
       // clang-format off
-      ss << R"(extern "C" {\n )"
+      ss << R"(extern "C" {)" << "\n"
 				 << resolve(body)
 				 << "}\n";
       // clang-format on

--- a/src/crow/codegen/cpp_backend/cpp_backend.cpp
+++ b/src/crow/codegen/cpp_backend/cpp_backend.cpp
@@ -318,7 +318,32 @@ auto CppBackend::visit(Variable* t_var) -> Any
 // Meta:
 auto CppBackend::visit(Attribute* t_attr) -> Any
 {
+  using ast::node::node_traits::AttributeType;
+  using ast::node::node_traits::str2attribute_type;
+
   std::stringstream ss{};
+
+  const auto id{t_attr->identifier()};
+  const auto params{t_attr->params()};
+  const auto body{t_attr->body()};
+
+  // TODO: This should probably be somewhere else.
+  // Also we should not allow the extern attribute, inside of function bodies.
+  const auto attr_type{str2attribute_type(id)};
+  switch(attr_type) {
+    case AttributeType::EXTERN:
+      // clang-format off
+      ss << R"(extern "C" {\n )"
+				 << resolve(body)
+				 << "}\n";
+      // clang-format on
+      break;
+
+    default:
+      // Walk the body like normal.
+      ss << resolve(body);
+      break;
+  }
 
   return ss.str();
 }

--- a/src/crow/codegen/cpp_backend/cpp_backend.cpp
+++ b/src/crow/codegen/cpp_backend/cpp_backend.cpp
@@ -283,7 +283,7 @@ auto CppBackend::visit([[maybe_unused]] ReturnType* t_rt) -> Any
 auto CppBackend::visit(Let* t_let) -> Any
 {
   const auto identifier{t_let->identifier()};
-  const auto init_expr{resolve(t_let->init_expr())};
+  const auto init_expr{resolve(t_let->init_expr(), false)};
 
   const auto type_variant{t_let->get_type()};
   const auto type{type_variant2cpp(type_variant)};
@@ -297,7 +297,7 @@ auto CppBackend::visit(Let* t_let) -> Any
 auto CppBackend::visit(Var* t_var) -> Any
 {
   const auto identifier{t_var->identifier()};
-  const auto init_expr{resolve(t_var->init_expr())};
+  const auto init_expr{resolve(t_var->init_expr(), false)};
 
   const auto type_variant{t_var->get_type()};
   const auto type{type_variant2cpp(type_variant)};

--- a/src/crow/codegen/cpp_backend/cpp_backend.cpp
+++ b/src/crow/codegen/cpp_backend/cpp_backend.cpp
@@ -88,7 +88,7 @@ auto CppBackend::terminate() -> std::string_view
 // TODO: Add inline option for direct resolution.
 auto CppBackend::resolve(NodePtr t_ptr, const bool t_terminate) -> std::string
 {
-  std::stringstream ss;
+  std::stringstream ss{};
 
   if(t_ptr) {
     // Keep track of if the current node we are traversing should be terminated.
@@ -142,7 +142,7 @@ auto CppBackend::visit(Loop* t_loop) -> Any
   const auto post_expr{resolve(t_loop->expr(), false)};
   const auto body{resolve(t_loop->body())};
 
-  std::stringstream ss;
+  std::stringstream ss{};
 
   // clang-format off
   ss << std::format("for({};{}; {} )", init_expr, cond, post_expr)
@@ -166,7 +166,7 @@ auto CppBackend::visit([[maybe_unused]] Break* t_break) -> Any
 
 auto CppBackend::visit(Defer* t_defer) -> Any
 {
-  std::stringstream ss;
+  std::stringstream ss{};
 
   const auto body{resolve(t_defer->body())};
 
@@ -270,10 +270,12 @@ auto CppBackend::visit(Call* t_call) -> Any
 
 auto CppBackend::visit([[maybe_unused]] ReturnType* t_rt) -> Any
 {
+  std::stringstream ss{};
+
   // Currently we do not dynamically compute return types.
   // So for now converting a type_variant2cpp() is good enough.
 
-  return {};
+  return ss.str();
 }
 
 // Lvalue:
@@ -314,25 +316,11 @@ auto CppBackend::visit(Variable* t_var) -> Any
 }
 
 // Meta:
-auto CppBackend::visit(FunctionDecl* t_fdecl) -> Any
+auto CppBackend::visit(Attribute* t_attr) -> Any
 {
-  const auto identifier{t_fdecl->identifier()};
+  std::stringstream ss{};
 
-  const auto fn_type{t_fdecl->get_type().function()};
-  const auto ret_type{type_variant2cpp(fn_type->m_return_type)};
-
-  std::stringstream param_ss{};
-
-  auto sep{""sv};
-  const auto params{t_fdecl->params()};
-  for(const auto& param : *params) {
-    param_ss << sep << resolve(param);
-
-    sep = ", ";
-  }
-
-  return std::format("auto {}({}) -> {};\n", identifier, param_ss.str(),
-                     ret_type);
+  return ss.str();
 }
 
 auto CppBackend::visit(LetDecl* t_ldecl) -> Any
@@ -353,6 +341,27 @@ auto CppBackend::visit(VarDecl* t_vdecl) -> Any
   const auto type{type_variant2cpp(type_variant)};
 
   return std::format("extern {} {};\n", type, identifier);
+}
+
+auto CppBackend::visit(FunctionDecl* t_fdecl) -> Any
+{
+  const auto identifier{t_fdecl->identifier()};
+
+  const auto fn_type{t_fdecl->get_type().function()};
+  const auto ret_type{type_variant2cpp(fn_type->m_return_type)};
+
+  std::stringstream param_ss{};
+
+  auto sep{""sv};
+  const auto params{t_fdecl->params()};
+  for(const auto& param : *params) {
+    param_ss << sep << resolve(param);
+
+    sep = ", ";
+  }
+
+  return std::format("auto {}({}) -> {};\n", identifier, param_ss.str(),
+                     ret_type);
 }
 
 // Operators:
@@ -504,13 +513,22 @@ AST_VISITOR_STUB(CppBackend, DotExpr)
 // Misc:
 auto CppBackend::visit(List* t_list) -> Any
 {
-  std::stringstream ss;
+  std::stringstream ss{};
 
   for(NodePtr& node : *t_list) {
     ss << resolve(node);
   }
 
   return ss.str();
+}
+
+auto CppBackend::visit(NodeInterface* t_t_node) -> Any
+{
+  // We only call this method if we have not overriden.
+  // The visit method for that AST node.
+  RUNTIME_ERROR("Unimplemented visit() method for AST node.");
+
+  return {};
 }
 
 // Util:
@@ -594,7 +612,6 @@ auto CppBackend::compile(CompileParams& t_params) -> void
 
   fs::path stem{source_path.stem()};
   const fs::path tmp_src{build_dir / stem.concat(".cpp")};
-
 
   // Log filepath's:
   DBG_INFO("build_dir: ", build_dir);

--- a/src/crow/codegen/cpp_backend/cpp_backend.cpp
+++ b/src/crow/codegen/cpp_backend/cpp_backend.cpp
@@ -197,6 +197,8 @@ auto CppBackend::visit(Parameter* t_param) -> Any
 
 auto CppBackend::visit(Function* t_fn) -> Any
 {
+  using node::node_traits::AttributeType;
+
   const auto identifier{t_fn->identifier()};
 
   const auto fn_type{t_fn->get_type().function()};
@@ -213,6 +215,12 @@ auto CppBackend::visit(Function* t_fn) -> Any
   }
 
   std::stringstream ss{};
+
+  // Attribute insertion:
+  const auto attr{t_fn->get_attribute()};
+  if(attr.m_type == AttributeType::INLINE) {
+    ss << "inline\n";
+  }
 
   // clang-format off
   ss << std::format("auto {}({}) -> {}\n", identifier, param_ss.str(), ret_type)
@@ -318,8 +326,7 @@ auto CppBackend::visit(Variable* t_var) -> Any
 // Meta:
 auto CppBackend::visit(Attribute* t_attr) -> Any
 {
-  using ast::node::node_traits::AttributeType;
-  using ast::node::node_traits::str2attribute_type;
+  using node::node_traits::AttributeType;
 
   std::stringstream ss{};
 
@@ -329,8 +336,8 @@ auto CppBackend::visit(Attribute* t_attr) -> Any
 
   // TODO: This should probably be somewhere else.
   // Also we should not allow the extern attribute, inside of function bodies.
-  const auto attr_type{str2attribute_type(id)};
-  switch(attr_type) {
+  const auto attr{t_attr->get_attribute()};
+  switch(attr.m_type) {
     case AttributeType::EXTERN:
       // clang-format off
       ss << R"(extern "C" {)" << "\n"

--- a/src/crow/codegen/cpp_backend/cpp_backend.cpp
+++ b/src/crow/codegen/cpp_backend/cpp_backend.cpp
@@ -217,9 +217,11 @@ auto CppBackend::visit(Function* t_fn) -> Any
   std::stringstream ss{};
 
   // Attribute insertion:
-  const auto attr{t_fn->get_attribute()};
-  if(attr.m_type == AttributeType::INLINE) {
-    ss << "inline\n";
+  const auto attrs{t_fn->get_attributes()};
+  for(const auto& attr : attrs) {
+    if(attr.m_type == AttributeType::INLINE) {
+      ss << "inline\n";
+    }
   }
 
   // clang-format off
@@ -336,20 +338,22 @@ auto CppBackend::visit(Attribute* t_attr) -> Any
 
   // TODO: This should probably be somewhere else.
   // Also we should not allow the extern attribute, inside of function bodies.
-  const auto attr{t_attr->get_attribute()};
-  switch(attr.m_type) {
-    case AttributeType::EXTERN:
-      // clang-format off
+  const auto attrs{t_attr->get_attributes()};
+  for(const auto& attr : attrs) {
+    switch(attr.m_type) {
+      case AttributeType::EXTERN:
+        // clang-format off
       ss << R"(extern "C" {)" << "\n"
 				 << resolve(body)
 				 << "}\n";
-      // clang-format on
-      break;
+        // clang-format on
+        break;
 
-    default:
-      // Walk the body like normal.
-      ss << resolve(body);
-      break;
+      default:
+        // Walk the body like normal.
+        ss << resolve(body);
+        break;
+    }
   }
 
   return ss.str();

--- a/src/crow/codegen/cpp_backend/cpp_backend.hpp
+++ b/src/crow/codegen/cpp_backend/cpp_backend.hpp
@@ -107,9 +107,10 @@ class CppBackend : public NodeVisitor, public BackendInterface {
   auto visit(node::lvalue::Variable* t_var) -> Any override;
 
   // Meta:
-  auto visit(node::meta::FunctionDecl* t_fdecl) -> Any override;
+  auto visit(node::meta::Attribute* t_attr) -> Any override;
   auto visit(node::meta::LetDecl* t_ldecl) -> Any override;
   auto visit(node::meta::VarDecl* t_vdecl) -> Any override;
+  auto visit(node::meta::FunctionDecl* t_fdecl) -> Any override;
 
   // Operators:
   auto visit(node::operators::Arithmetic* t_arith) -> Any override;
@@ -148,6 +149,7 @@ class CppBackend : public NodeVisitor, public BackendInterface {
 
   // Misc:
   auto visit(node::List* t_list) -> Any override;
+  auto visit(node::NodeInterface* t_node) -> Any override;
 
   // Util:
   //! CPP backend as of writing needs to refactor interop.

--- a/src/crow/codegen/cpp_backend/type2cpp.cpp
+++ b/src/crow/codegen/cpp_backend/type2cpp.cpp
@@ -50,13 +50,14 @@ auto native_type2cpp(const NativeType t_type) -> std::string_view
 
     MATCH(BOOL, "bool");
 
-    default:
+    default: {
       const auto msg{
         std::format("NativeType could not be converted to C++ type: ",
                     nativetype2str(t_type))};
 
       throw std::invalid_argument{msg};
       break;
+    }
   }
 
   return str;

--- a/src/crow/mir/mir_builder/mir_builder.cpp
+++ b/src/crow/mir/mir_builder/mir_builder.cpp
@@ -291,6 +291,8 @@ auto MirBuilder::visit(Attribute* t_attr) -> Any
 
   // TODO: Think about what else to do with attributes, during MIR generation.
   traverse(body);
+
+  return {};
 }
 
 auto MirBuilder::visit(LetDecl* t_ldecl) -> Any

--- a/src/crow/mir/mir_builder/mir_builder.cpp
+++ b/src/crow/mir/mir_builder/mir_builder.cpp
@@ -285,20 +285,12 @@ auto MirBuilder::visit(Variable* t_var) -> Any
 }
 
 // Meta:
-auto MirBuilder::visit(FunctionDecl* t_fdecl) -> Any
+auto MirBuilder::visit(Attribute* t_attr) -> Any
 {
-  FunctionPtr fn{std::make_shared<Function>()};
+  const auto body{t_attr->body()};
 
-  const auto id{t_fdecl->identifier()};
-
-  // We only need to add the name for the declaration.
-  // During semantic analysis we confirm, that the declaration.
-  // Matches the definition.
-  fn->m_name = id;
-
-  m_factory->add_function_declaration(fn);
-
-  return {};
+  // TODO: Think about what else to do with attributes, during MIR generation.
+  traverse(body);
 }
 
 auto MirBuilder::visit(LetDecl* t_ldecl) -> Any
@@ -317,6 +309,22 @@ auto MirBuilder::visit(VarDecl* t_vdecl) -> Any
   const auto type{t_vdecl->get_type()};
 
   m_factory->add_global_declaration(name, type);
+
+  return {};
+}
+
+auto MirBuilder::visit(FunctionDecl* t_fdecl) -> Any
+{
+  FunctionPtr fn{std::make_shared<Function>()};
+
+  const auto id{t_fdecl->identifier()};
+
+  // We only need to add the name for the declaration.
+  // During semantic analysis we confirm, that the declaration.
+  // Matches the definition.
+  fn->m_name = id;
+
+  m_factory->add_function_declaration(fn);
 
   return {};
 }

--- a/src/crow/mir/mir_builder/mir_builder.cpp
+++ b/src/crow/mir/mir_builder/mir_builder.cpp
@@ -620,18 +620,30 @@ auto MirBuilder::visit(UnaryPrefix* t_up) -> Any
   const auto op{t_up->op()};
   const auto left{t_up->left()};
 
+  traverse(left);
+  const auto last_var{m_factory->require_last_var()};
+  const auto type{last_var->m_type};
+
   switch(op) {
-    case UnaryPrefixOp::PLUS:
+    case UnaryPrefixOp::PLUS: {
       // TODO: Determine if float or integer.
       // TODO: No op.
       break;
+    }
 
-    case UnaryPrefixOp::MINUS:
-      // TODO: Determine if float or integer.
-      // m_factory->add_instruction(Opcode::ISUB);
+    case UnaryPrefixOp::MINUS: {
+      // TODO: Determine if float or integer, dont allow unsigned integers.
+      auto& sub_instr{m_factory->add_instruction(Opcode::ISUB)};
+
+      Literal lit{NativeType::INT, 0};
+      sub_instr.add_operand(lit);
+      sub_instr.add_operand(last_var);
+
+      m_factory->add_result_var(type);
 
       // TODO: Traverse left.
       break;
+    }
 
     default:
       // TODO: THROW!

--- a/src/crow/mir/mir_builder/mir_builder.hpp
+++ b/src/crow/mir/mir_builder/mir_builder.hpp
@@ -54,9 +54,10 @@ class MirBuilder : public NodeVisitor {
   auto visit(node::lvalue::Variable* t_var) -> Any override;
 
   // Meta:
-  auto visit(node::meta::FunctionDecl* t_fdecl) -> Any override;
+  auto visit(node::meta::Attribute* t_attr) -> Any override;
   auto visit(node::meta::LetDecl* t_ldecl) -> Any override;
   auto visit(node::meta::VarDecl* t_vdecl) -> Any override;
+  auto visit(node::meta::FunctionDecl* t_fdecl) -> Any override;
 
   // Operators:
   auto visit(node::operators::Arithmetic* t_arith) -> Any override;

--- a/src/crow/mir/mir_builder/mir_module_factory.cpp
+++ b/src/crow/mir/mir_builder/mir_module_factory.cpp
@@ -335,7 +335,7 @@ auto MirModuleFactory::add_call(const std::string_view t_name,
   // Insert a weak reference to the function as operand.
   // FIXME: But this fails when we only have a declaration of a function.
   // Which occurs when we declare an extern C function.
-	// We need to have a fix for this.
+  // We need to have a fix for this.
   FunctionLabel label{FunctionWeakPtr{entity.m_entity}};
   call_instr.add_operand({label});
 

--- a/src/crow/mir/mir_builder/mir_module_factory.cpp
+++ b/src/crow/mir/mir_builder/mir_module_factory.cpp
@@ -333,6 +333,9 @@ auto MirModuleFactory::add_call(const std::string_view t_name,
   const FunctionMirEntity& entity{m_fn_env.get_value(t_name)};
 
   // Insert a weak reference to the function as operand.
+  // FIXME: But this fails when we only have a declaration of a function.
+  // Which occurs when we declare an extern C function.
+	// We need to have a fix for this.
   FunctionLabel label{FunctionWeakPtr{entity.m_entity}};
   call_instr.add_operand({label});
 

--- a/src/crow/parser/crow/crow.yy
+++ b/src/crow/parser/crow/crow.yy
@@ -303,10 +303,10 @@ function_call    : chain_expr '(' expr_list_opt')'
                  ;
 
 // Meta:
-attribute_item : declare
-               | decl_expr
-               | function
-               ;
+attribute_item   : declare
+                 | decl_expr
+                 | function
+                 ;
 
 attribute_item_list : attribute_item newline_opt
                     | attribute_item_list newline_opt attribute_item
@@ -316,8 +316,8 @@ attribute_body   : attribute_item
                  | '{' attribute_item_list'}'
 								 ;
 
-attribute        : ATTRIBUTE_OPEN identifier ATTRIBUTE_CLOSE attribute_body
-		             | ATTRIBUTE_OPEN identifier '(' literal_list ')' ATTRIBUTE_CLOSE attribute_body
+attribute        : ATTRIBUTE_OPEN identifier ATTRIBUTE_CLOSE newline_opt attribute_body
+		             | ATTRIBUTE_OPEN identifier '(' literal_list ')' ATTRIBUTE_CLOSE newline_opt attribute_body
                  ;
 
 

--- a/src/crow/parser/crow/crow.yy
+++ b/src/crow/parser/crow/crow.yy
@@ -313,7 +313,7 @@ attribute_item_list : attribute_item newline_opt
                     ;
 
 attribute_body   : attribute_item
-                 | '{' attribute_item_list'}'
+                 | '{' newline_opt attribute_item_list'}'
 								 ;
 
 attribute        : ATTRIBUTE_OPEN identifier ATTRIBUTE_CLOSE newline_opt attribute_body

--- a/src/crow/parser/crow/crow.yy
+++ b/src/crow/parser/crow/crow.yy
@@ -303,7 +303,8 @@ function_call    : chain_expr '(' expr_list_opt')'
                  ;
 
 // Meta:
-attribute_item : decl_expr
+attribute_item : declare
+               | decl_expr
                | function
                ;
 

--- a/src/crow/parser/crow/crow.yy
+++ b/src/crow/parser/crow/crow.yy
@@ -303,7 +303,8 @@ function_call    : chain_expr '(' expr_list_opt')'
                  ;
 
 // Meta:
-attribute_item   : declare
+attribute_item   : attribute
+                 | declare
                  | decl_expr
                  | function
                  ;

--- a/src/crow/parser/crow/crow.yy
+++ b/src/crow/parser/crow/crow.yy
@@ -7,6 +7,10 @@
 // Package:
 %token Module Import Private Public
 
+// Meta:
+%token Declare
+%token ATTRIBUTE_OPEN ATTRIBUTE_CLOSE
+
 // Typing:
 %token Enum Struct
 
@@ -69,6 +73,14 @@ literal          : NUMBER
                  | STRING
                  | TRUE
                  | FALSE
+                 ;
+
+literal_list     : literal
+                 | literal_list ',' newline_opt literal
+                 ;
+
+expr_list_opt    : // empty
+                 | expr_list
                  ;
 
 grouping         : '(' expr ')'
@@ -155,8 +167,8 @@ assignment       : lvalue MUL_ASSIGN newline_opt expr
                  | lvalue ADD_ASSIGN newline_opt expr
                  | lvalue SUB_ASSIGN newline_opt expr
                  | lvalue '=' newline_opt expr
-		 | lvalue INCREMENT
-		 | lvalue DECREMENT
+		             | lvalue INCREMENT
+		             | lvalue DECREMENT
                  ;
 
 result_statement : decl_expr terminator
@@ -236,11 +248,6 @@ body             : newline_opt '{' newline_opt '}'
                  | newline_opt '{' newline_opt statement_list newline_opt '}'
                  ;
 
-// Attributes:
-attribute        : Private
-		             | Public
-                 ;
-
 // Typing:
 // TODO: Figure out how to name aliases?
 /* alias_def     : Alias? */
@@ -295,6 +302,24 @@ function         : Func IDENTIFIER '(' param_list_opt ')' return_type_opt body
 function_call    : chain_expr '(' expr_list_opt')'
                  ;
 
+// Meta:
+attribute_item : decl_expr
+               | function
+               ;
+
+attribute_item_list : attribute_item newline_opt
+                    | attribute_item_list newline_opt attribute_item
+                    ;
+
+attribute_body   : attribute_item
+                 | '{' attribute_item_list'}'
+								 ;
+
+attribute        : ATTRIBUTE_OPEN identifier ATTRIBUTE_CLOSE attribute_body
+		             | ATTRIBUTE_OPEN identifier '(' literal_list ')' ATTRIBUTE_CLOSE attribute_body
+                 ;
+
+
 declare          : Declare Let IDENTIFIER : IDENTIFIER newline_opt
                  | Declare Var IDENTIFIER : IDENTIFIER newline_opt
                  | Declare Func IDENTIFIER '(' param_list_opt ')' return_type_opt newline_opt
@@ -313,7 +338,7 @@ import           : Import STRING
                  | Import '(' newline_opt import_list ')'
                  ;
 
-// Packaging:
+// Package:
 module_decl      : Module IDENTIFIER
                  ;
 
@@ -325,6 +350,7 @@ module_decl      : Module IDENTIFIER
 item             : module_decl
 				         | import
 								 | declare
+								 | attribute
 				         | type_def
 				         | decl_expr
                  | function

--- a/src/crow/parser/crow/crow_parser.cpp
+++ b/src/crow/parser/crow/crow_parser.cpp
@@ -711,11 +711,13 @@ auto CrowParser::attribute_body() -> NodeListPtr
 
   if(check(TokenType::ACCOLADE_OPEN)) {
     nodes = attribute_item_list();
+    newline_opt();
     expect(TokenType::ACCOLADE_CLOSE);
   } else if(auto ptr{attribute_item()}; ptr) {
     nodes->push_back(std::move(ptr));
+    newline_opt();
   } else {
-    throw_syntax_error("Expected an attribute item.");
+    throw_syntax_error("Expected an attribute item or body.");
   }
 
   return nodes;
@@ -727,6 +729,7 @@ auto CrowParser::attribute() -> NodePtr
   NodePtr node{};
 
   if(next_if(TokenType::ATTRIBUTE_OPEN)) {
+    PARSER_FOUND(TokenType::ATTRIBUTE_OPEN);
     const auto id{expect(TokenType::IDENTIFIER).str()};
     NodeListPtr params_ptr{};
     NodeListPtr body_ptr{make_node<List>()};
@@ -740,6 +743,7 @@ auto CrowParser::attribute() -> NodePtr
     expect(TokenType::ATTRIBUTE_CLOSE);
 
     // Get the item or body.
+    newline_opt();
     body_ptr = attribute_body();
 
     node = make_node<Attribute>(id, std::move(params_ptr), std::move(body_ptr));

--- a/src/crow/parser/crow/crow_parser.cpp
+++ b/src/crow/parser/crow/crow_parser.cpp
@@ -64,6 +64,36 @@ auto CrowParser::terminator() -> void
   }
 }
 
+auto CrowParser::literal_list() -> NodeListPtr
+{
+  DBG_TRACE_FN(VERBOSE);
+  auto nodes{make_node<List>()};
+
+  auto pos{get_position()};
+  if(auto first_ptr{literal()}; first_ptr) {
+    nodes->push_back(std::move(first_ptr));
+
+    while(!eos()) {
+      if(next_if(TokenType::COMMA)) {
+        auto ptr{literal()};
+        if(!ptr) {
+          throw_syntax_error("Expected another literal!");
+        }
+
+        nodes->push_back(std::move(ptr));
+      } else {
+        break;
+      }
+    }
+  }
+
+  if(nodes->empty()) {
+    throw_syntax_error("Expected a list of literals");
+  }
+
+  return nodes;
+}
+
 auto CrowParser::expr_opt() -> NodePtr
 {
   DBG_TRACE_FN(VERBOSE);
@@ -77,7 +107,7 @@ auto CrowParser::init_expr(const TokenType t_type) -> NodePtr
   using namespace token;
 
   DBG_TRACE_FN(VERBOSE);
-  NodePtr node;
+  NodePtr node{};
 
   const auto pos{get_position()};
   if(next_if(t_type)) {
@@ -135,7 +165,7 @@ auto CrowParser::var_expr() -> NodePtr
 auto CrowParser::decl_expr() -> NodePtr
 {
   DBG_TRACE_FN(VERBOSE);
-  NodePtr node;
+  NodePtr node{};
 
   if(auto ptr{var_expr()}; ptr) {
     node = std::move(ptr);
@@ -165,7 +195,7 @@ auto CrowParser::eval_expr() -> EvalPair
 auto CrowParser::expr_statement() -> NodePtr
 {
   DBG_TRACE_FN(VERBOSE);
-  NodePtr node;
+  NodePtr node{};
 
   if(auto ptr{expr()}; ptr) {
     terminator();
@@ -220,7 +250,7 @@ auto CrowParser::expr_list_opt() -> NodeListPtr
 auto CrowParser::assignment() -> NodePtr
 {
   DBG_TRACE_FN(VERBOSE);
-  NodePtr node;
+  NodePtr node{};
 
   if(auto lhs{lvalue()}; lhs) {
     const auto pos{get_position()};
@@ -271,7 +301,7 @@ auto CrowParser::assignment() -> NodePtr
 auto CrowParser::result_statement() -> NodePtr
 {
   DBG_TRACE_FN(VERBOSE);
-  NodePtr node;
+  NodePtr node{};
 
   if(auto ptr{function_call()}; ptr) {
     node = std::move(ptr);
@@ -292,7 +322,7 @@ auto CrowParser::result_statement() -> NodePtr
 auto CrowParser::jump_statement() -> NodePtr
 {
   DBG_TRACE_FN(VERBOSE);
-  NodePtr node;
+  NodePtr node{};
 
   if(check(TokenType::CONTINUE)) {
     context_check(Context::LOOP);
@@ -331,7 +361,7 @@ auto CrowParser::jump_statement() -> NodePtr
 auto CrowParser::loop_statement() -> NodePtr
 {
   DBG_TRACE_FN(VERBOSE);
-  NodePtr node;
+  NodePtr node{};
 
   const auto pos{get_position()};
   if(next_if(TokenType::LOOP)) {
@@ -355,7 +385,7 @@ auto CrowParser::loop_statement() -> NodePtr
 auto CrowParser::branch_statement(const TokenType t_type) -> NodePtr
 {
   DBG_TRACE_FN(VERBOSE);
-  NodePtr node;
+  NodePtr node{};
 
   const auto pos{get_position()};
   if(next_if(t_type)) {
@@ -366,7 +396,7 @@ auto CrowParser::branch_statement(const TokenType t_type) -> NodePtr
 
     auto then_ptr{body()};
 
-    NodeListPtr alt_ptr;
+    NodeListPtr alt_ptr{};
     if(next_if(TokenType::ELSE)) {
       alt_ptr = body();
     } else if(auto ptr{branch_statement(TokenType::ELIF)}; ptr) {
@@ -385,7 +415,7 @@ auto CrowParser::branch_statement(const TokenType t_type) -> NodePtr
 auto CrowParser::if_statement() -> NodePtr
 {
   DBG_TRACE_FN(VERBOSE);
-  NodePtr node;
+  NodePtr node{};
 
   return branch_statement(TokenType::IF);
 }
@@ -401,7 +431,7 @@ auto CrowParser::elif_statement() -> NodePtr
 auto CrowParser::statement() -> NodePtr
 {
   DBG_TRACE_FN(VERBOSE);
-  NodePtr node;
+  NodePtr node{};
 
   if(auto ptr{decl_expr()}; ptr) {
     terminator();
@@ -447,7 +477,7 @@ auto CrowParser::statement_list() -> NodeListPtr
 auto CrowParser::body() -> NodeListPtr
 {
   DBG_TRACE_FN(VERBOSE);
-  NodeListPtr nodes;
+  NodeListPtr nodes{};
 
   // After a list of newlines an accolade most occur
   if(after_newlines(TokenType::ACCOLADE_OPEN)) {
@@ -468,7 +498,7 @@ auto CrowParser::body() -> NodeListPtr
 auto CrowParser::member_decl() -> NodePtr
 {
   DBG_TRACE_FN(VERBOSE);
-  NodePtr node;
+  NodePtr node{};
 
   const auto token{get_token()};
   if(next_if(TokenType::IDENTIFIER)) {
@@ -496,7 +526,7 @@ auto CrowParser::member_decl_list() -> NodeListPtr
 auto CrowParser::struct_def() -> NodePtr
 {
   DBG_TRACE_FN(VERBOSE);
-  NodePtr node;
+  NodePtr node{};
 
   if(next_if(TokenType::STRUCT)) {
     PARSER_FOUND(TokenType::STRUCT);
@@ -519,7 +549,7 @@ auto CrowParser::struct_def() -> NodePtr
 auto CrowParser::type_def() -> NodePtr
 {
   DBG_TRACE_FN(VERBOSE);
-  NodePtr node;
+  NodePtr node{};
 
   if(auto ptr{struct_def()}; ptr) {
     node = std::move(ptr);
@@ -604,7 +634,7 @@ auto CrowParser::return_type_opt() -> std::string
 auto CrowParser::lambda() -> NodePtr
 {
   DBG_TRACE_FN(VERBOSE);
-  NodePtr node;
+  NodePtr node{};
 
   if(next_if(TokenType::FUNCTION)) {
     auto params{parens([this] {
@@ -618,7 +648,7 @@ auto CrowParser::lambda() -> NodePtr
 auto CrowParser::function() -> NodePtr
 {
   DBG_TRACE_FN(VERBOSE);
-  NodePtr node;
+  NodePtr node{};
 
   if(next_if(TokenType::FUNCTION)) {
     const auto tt_id{expect(TokenType::IDENTIFIER)};
@@ -643,10 +673,85 @@ auto CrowParser::function() -> NodePtr
   return node;
 }
 
+auto CrowParser::attribute_item() -> NodePtr
+{
+  DBG_TRACE_FN(VERBOSE);
+  NodePtr node{};
+
+  // TODO: Maybe also make declarations attributable?
+
+  if(auto ptr{decl_expr()}; ptr) {
+    node = std::move(ptr);
+  } else if(auto ptr{function()}; ptr) {
+    node = std::move(ptr);
+  }
+
+  return node;
+}
+
+auto CrowParser::attribute_item_list() -> NodeListPtr
+{
+  DBG_TRACE_FN(VERBOSE);
+
+  return list_of([this] {
+    NodePtr attr_item{attribute_item()};
+
+    if(attr_item) {
+      newline_opt();
+    }
+
+    return attr_item;
+  });
+}
+
+auto CrowParser::attribute_body() -> NodeListPtr
+{
+  DBG_TRACE_FN(VERBOSE);
+  auto nodes{make_node<List>()};
+
+  if(check(TokenType::ACCOLADE_OPEN)) {
+    nodes = attribute_item_list();
+    expect(TokenType::ACCOLADE_CLOSE);
+  } else if(auto ptr{attribute_item()}; ptr) {
+    nodes->push_back(std::move(ptr));
+  } else {
+    throw_syntax_error("Expected an attribute item.");
+  }
+
+  return nodes;
+}
+
+auto CrowParser::attribute() -> NodePtr
+{
+  DBG_TRACE_FN(VERBOSE);
+  NodePtr node{};
+
+  if(next_if(TokenType::ATTRIBUTE_OPEN)) {
+    const auto id{expect(TokenType::IDENTIFIER).str()};
+    NodeListPtr params_ptr{};
+    NodeListPtr body_ptr{make_node<List>()};
+
+    // Get any potential parameters (can be nullptr or zero).
+    if(next_if(TokenType::PAREN_OPEN)) {
+      params_ptr = literal_list();
+
+      expect(TokenType::PAREN_CLOSE);
+    }
+    expect(TokenType::ATTRIBUTE_CLOSE);
+
+    // Get the item or body.
+    body_ptr = attribute_body();
+
+    node = make_node<Attribute>(id, std::move(params_ptr), std::move(body_ptr));
+  }
+
+  return node;
+}
+
 auto CrowParser::declare() -> NodePtr
 {
   DBG_TRACE_FN(VERBOSE);
-  NodePtr node;
+  NodePtr node{};
 
   if(next_if(TokenType::DECLARE)) {
     PARSER_FOUND(TokenType::DECLARE);
@@ -741,7 +846,7 @@ auto CrowParser::import_list(Import& t_import) -> void
 auto CrowParser::import_() -> NodePtr
 {
   DBG_TRACE_FN(VERBOSE);
-  NodePtr node;
+  NodePtr node{};
 
   if(next_if(TokenType::IMPORT)) {
     PARSER_FOUND(TokenType::IMPORT);
@@ -770,7 +875,7 @@ auto CrowParser::import_() -> NodePtr
 auto CrowParser::module_decl() -> NodePtr
 {
   DBG_TRACE_FN(VERBOSE);
-  NodePtr node;
+  NodePtr node{};
 
   if(next_if(TokenType::MODULE)) {
     PARSER_FOUND(TokenType::MODULE);
@@ -785,11 +890,13 @@ auto CrowParser::module_decl() -> NodePtr
 auto CrowParser::item() -> NodePtr
 {
   DBG_TRACE_FN(VERBOSE);
-  NodePtr node;
+  NodePtr node{};
 
   if(auto ptr{import_()}; ptr) {
     node = std::move(ptr);
   } else if(auto ptr{declare()}; ptr) {
+    node = std::move(ptr);
+  } else if(auto ptr{attribute()}; ptr) {
     node = std::move(ptr);
   } else if(auto ptr{type_def()}; ptr) {
     node = std::move(ptr);
@@ -807,7 +914,7 @@ auto CrowParser::item() -> NodePtr
 auto CrowParser::item_list() -> NodeListPtr
 {
   DBG_TRACE_FN(VERBOSE);
-  NodePtr node;
+  NodePtr node{};
 
   // Check for the
   if(auto ptr{module_decl()}; ptr) {
@@ -847,6 +954,13 @@ auto CrowParser::program() -> NodeListPtr
 
 auto CrowParser::parse() -> NodePtr
 {
-  return program();
+  const auto ast{program()};
+
+  // TODO: Check if we are at EOS.
+  // If we are not at EOS, then we didnt parse everything.
+  // Which is a parsing error or syntax error.
+  // As the entirety of the token stream should be parsed and accounted for.
+
+  return ast;
 }
 } // namespace parser::crow

--- a/src/crow/parser/crow/crow_parser.cpp
+++ b/src/crow/parser/crow/crow_parser.cpp
@@ -709,7 +709,9 @@ auto CrowParser::attribute_body() -> NodeListPtr
   DBG_TRACE_FN(VERBOSE);
   auto nodes{make_node<List>()};
 
-  if(check(TokenType::ACCOLADE_OPEN)) {
+  if(next_if(TokenType::ACCOLADE_OPEN)) {
+    PARSER_FOUND(TokenType::ACCOLADE_OPEN);
+    newline_opt();
     nodes = attribute_item_list();
     newline_opt();
     expect(TokenType::ACCOLADE_CLOSE);

--- a/src/crow/parser/crow/crow_parser.cpp
+++ b/src/crow/parser/crow/crow_parser.cpp
@@ -678,7 +678,9 @@ auto CrowParser::attribute_item() -> NodePtr
   DBG_TRACE_FN(VERBOSE);
   NodePtr node{};
 
-  if(auto ptr{declare()}; ptr) {
+  if(auto ptr{attribute()}; ptr) {
+    node = std::move(ptr);
+  } else if(auto ptr{declare()}; ptr) {
     node = std::move(ptr);
   } else if(auto ptr{decl_expr()}; ptr) {
     node = std::move(ptr);

--- a/src/crow/parser/crow/crow_parser.cpp
+++ b/src/crow/parser/crow/crow_parser.cpp
@@ -678,9 +678,9 @@ auto CrowParser::attribute_item() -> NodePtr
   DBG_TRACE_FN(VERBOSE);
   NodePtr node{};
 
-  // TODO: Maybe also make declarations attributable?
-
-  if(auto ptr{decl_expr()}; ptr) {
+  if(auto ptr{declare()}; ptr) {
+    node = std::move(ptr);
+  } else if(auto ptr{decl_expr()}; ptr) {
     node = std::move(ptr);
   } else if(auto ptr{function()}; ptr) {
     node = std::move(ptr);

--- a/src/crow/parser/crow/crow_parser.hpp
+++ b/src/crow/parser/crow/crow_parser.hpp
@@ -46,6 +46,7 @@ class CrowParser : public pratt::PrattParser {
   virtual auto terminator() -> void;
 
   // Expressions:
+  virtual auto literal_list() -> NodeListPtr;
   virtual auto expr_opt() -> NodePtr;
 
   virtual auto init_expr(TokenType t_type) -> NodePtr;
@@ -98,6 +99,11 @@ class CrowParser : public pratt::PrattParser {
 
   virtual auto lambda() -> NodePtr;
   virtual auto function() -> NodePtr;
+
+  virtual auto attribute_item() -> NodePtr;
+  virtual auto attribute_item_list() -> NodeListPtr;
+  virtual auto attribute_body() -> NodeListPtr;
+  virtual auto attribute() -> NodePtr;
 
   virtual auto declare() -> NodePtr;
 

--- a/src/crow/semantic/semantic_checker.cpp
+++ b/src/crow/semantic/semantic_checker.cpp
@@ -503,19 +503,21 @@ auto SemanticChecker::visit(Variable* t_var) -> Any
 auto SemanticChecker::visit(Attribute* t_attr) -> Any
 {
   using ast::node::node_traits::AttributeArgs;
-  using ast::node::node_traits::str2attribute_type;
 
   const auto id{t_attr->identifier()};
   const auto params{t_attr->params()};
   const auto body{t_attr->body()};
 
   // TODO: Resolve parameters, and get them as strings.
+  AttributeArgs args{};
 
-  const auto attr_type{str2attribute_type(id)};
+  // We use set_attribute to
+  t_attr->set_attribute(id, args);
+  const auto attr{t_attr->get_attribute()};
 
   // Push the current attribute on the context stack.
   // So we can refer to them later.
-  m_attr_ctx.emplace(attr_type, std::string{id}, AttributeArgs{});
+  m_attr_ctx.push(attr);
 
   // Traverse body like normal.
   traverse(body);

--- a/src/crow/semantic/semantic_checker.cpp
+++ b/src/crow/semantic/semantic_checker.cpp
@@ -465,21 +465,13 @@ auto SemanticChecker::visit(Variable* t_var) -> Any
 }
 
 // Meta:
-auto SemanticChecker::visit(FunctionDecl* t_fdecl) -> Any
+auto SemanticChecker::visit(Attribute* t_attr) -> Any
 {
-  const auto id{t_fdecl->identifier()};
-  const auto ret_type{str2nativetype(t_fdecl->type())};
-  const auto params{t_fdecl->params()};
+  const auto id{t_attr->identifier()};
+  const auto params{t_attr->params()};
+  const auto body{t_attr->body()};
 
-  // Register function type signature to environment.
-  const auto params_type_list{get_type_list(params)};
-  const SymbolData data{symbol::make_function(params_type_list, ret_type)};
-
-  add_symbol_declaration(id, data);
-  DBG_INFO("FunctionDecl: ", id, "(", params_type_list, ") -> ", ret_type);
-
-  // Annotate AST.
-  t_fdecl->set_type(data.type_variant());
+  traverse(body);
 
   return {};
 }
@@ -510,6 +502,25 @@ auto SemanticChecker::visit(VarDecl* t_vdecl) -> Any
 
   // Annotate AST.
   t_vdecl->set_type(type_data);
+
+  return {};
+}
+
+auto SemanticChecker::visit(FunctionDecl* t_fdecl) -> Any
+{
+  const auto id{t_fdecl->identifier()};
+  const auto ret_type{str2nativetype(t_fdecl->type())};
+  const auto params{t_fdecl->params()};
+
+  // Register function type signature to environment.
+  const auto params_type_list{get_type_list(params)};
+  const SymbolData data{symbol::make_function(params_type_list, ret_type)};
+
+  add_symbol_declaration(id, data);
+  DBG_INFO("FunctionDecl: ", id, "(", params_type_list, ") -> ", ret_type);
+
+  // Annotate AST.
+  t_fdecl->set_type(data.type_variant());
 
   return {};
 }

--- a/src/crow/semantic/semantic_checker.cpp
+++ b/src/crow/semantic/semantic_checker.cpp
@@ -350,6 +350,7 @@ auto SemanticChecker::visit(Function* t_fn) -> Any
 
   // Annotate AST.
   annotate_type(t_fn, data);
+  annotate_attr(t_fn);
 
   // Register parameters to environment.
   push_env();
@@ -457,6 +458,7 @@ auto SemanticChecker::decl_expr(DeclExpr* t_decl) -> SymbolData
 
   // Annotate AST.
   annotate_type(t_decl, expr);
+  annotate_attr(t_decl);
 
   return expr;
 }
@@ -538,6 +540,7 @@ auto SemanticChecker::visit(LetDecl* t_ldecl) -> Any
 
   // Annotate AST.
   annotate_type(t_ldecl, type_data);
+  annotate_attr(t_ldecl);
 
   return {};
 }
@@ -553,6 +556,7 @@ auto SemanticChecker::visit(VarDecl* t_vdecl) -> Any
 
   // Annotate AST.
   annotate_type(t_vdecl, type_data);
+  annotate_attr(t_vdecl);
 
   return {};
 }
@@ -572,6 +576,7 @@ auto SemanticChecker::visit(FunctionDecl* t_fdecl) -> Any
 
   // Annotate AST.
   annotate_type(t_fdecl, data);
+  annotate_attr(t_fdecl);
 
   return {};
 }

--- a/src/crow/semantic/semantic_checker.cpp
+++ b/src/crow/semantic/semantic_checker.cpp
@@ -515,12 +515,12 @@ auto SemanticChecker::visit(Attribute* t_attr) -> Any
 
   // Push the current attribute on the context stack.
   // So we can refer to them later.
-  m_attr.ctx.emplace(attr_type, id, AttributeArgs{});
+  m_attr_ctx.emplace(attr_type, std::string{id}, AttributeArgs{});
 
   // Traverse body like normal.
   traverse(body);
 
-  m_attr.ctx.pop();
+  m_attr_ctx.pop();
 
   return {};
 }

--- a/src/crow/semantic/semantic_checker.cpp
+++ b/src/crow/semantic/semantic_checker.cpp
@@ -44,27 +44,15 @@ auto SemanticChecker::clear_env() -> void
   m_symbol_state.clear();
 }
 
-auto SemanticChecker::is_attr_active() const -> bool
-{
-  return (!m_attr_ctx.empty());
-}
-
-auto SemanticChecker::current_attr() const -> const AttributeMetadata&
-{
-  if(!is_attr_active()) {
-    // TODO: Throw.
-  }
-
-  return m_attr_ctx.top();
-}
-
 auto SemanticChecker::annotate_attr(AttributeData* t_node) -> void
 {
-  if(is_attr_active()) {
-    const auto& attr_metadata{current_attr()};
+  for(const auto& attr_node : m_attr_ctx) {
 
-    // Annotate AST, with AttributeMetadata.
-    t_node->set_attribute(attr_metadata);
+    const auto& attributes{attr_node->get_attributes()};
+
+    for(const auto& attr : attributes) {
+      t_node->add_attribute();
+    }
   }
 }
 
@@ -512,19 +500,19 @@ auto SemanticChecker::visit(Attribute* t_attr) -> Any
 
   // TODO: Resolve parameters, and get them as strings.
   AttributeArgs args{};
+  AttributeMetadata attr{id, args};
 
-  // We use set_attribute to
-  t_attr->set_attribute(id, args);
-  const auto attr{t_attr->get_attribute()};
+  // Annotate attribute.
+  t_attr->add_attribute(attr);
 
   // Push the current attribute on the context stack.
   // So we can refer to them later.
-  m_attr_ctx.push(attr);
+  m_attr_ctx.push_back(t_attr);
 
   // Traverse body like normal.
   traverse(body);
 
-  m_attr_ctx.pop();
+  m_attr_ctx.pop_back();
 
   return {};
 }

--- a/src/crow/semantic/semantic_checker.cpp
+++ b/src/crow/semantic/semantic_checker.cpp
@@ -46,13 +46,8 @@ auto SemanticChecker::clear_env() -> void
 
 auto SemanticChecker::annotate_attr(AttributeData* t_node) -> void
 {
-  for(const auto& attr_node : m_attr_ctx) {
-
-    const auto& attributes{attr_node->get_attributes()};
-
-    for(const auto& attr : attributes) {
-      t_node->add_attribute();
-    }
+  for(const auto& attr : m_active_attrs) {
+    t_node->add_attribute(attr);
   }
 }
 
@@ -248,7 +243,7 @@ auto SemanticChecker::get_resolved_type_list(NodeListPtr t_list)
 
 // Public methods:
 SemanticChecker::SemanticChecker()
-  : m_symbol_state{}, m_type_promoter{}, m_attr_ctx{}
+  : m_symbol_state{}, m_type_promoter{}, m_active_attrs{}
 {}
 
 // Control:
@@ -500,19 +495,19 @@ auto SemanticChecker::visit(Attribute* t_attr) -> Any
 
   // TODO: Resolve parameters, and get them as strings.
   AttributeArgs args{};
-  AttributeMetadata attr{id, args};
+  AttributeMetadata attr{id, std::move(args)};
 
   // Annotate attribute.
   t_attr->add_attribute(attr);
 
   // Push the current attribute on the context stack.
   // So we can refer to them later.
-  m_attr_ctx.push_back(t_attr);
+  m_active_attrs.push_back(attr);
 
   // Traverse body like normal.
   traverse(body);
 
-  m_attr_ctx.pop_back();
+  m_active_attrs.pop_back();
 
   return {};
 }

--- a/src/crow/semantic/semantic_checker.hpp
+++ b/src/crow/semantic/semantic_checker.hpp
@@ -45,7 +45,7 @@ using types::core::NativeType;
 using types::core::NativeTypeOpt;
 
 // Aliases:
-using AttributeContext = std::list<AttributeData*>;
+using AttributeContext = AttributeSeq;
 
 // Classes:
 // TODO: Add check for checking if the AST only has a single module declaration.
@@ -68,7 +68,7 @@ class SemanticChecker : public NodeVisitor {
   SymbolEnvState m_symbol_state;
   TypePromoter m_type_promoter;
 
-  AttributeContext m_attr_ctx;
+  AttributeContext m_active_attrs;
 
   protected:
   // Environment related methods:

--- a/src/crow/semantic/semantic_checker.hpp
+++ b/src/crow/semantic/semantic_checker.hpp
@@ -121,9 +121,10 @@ class SemanticChecker : public NodeVisitor {
   auto visit(node::lvalue::Variable* t_var) -> Any override;
 
   // Meta:
-  auto visit(node::meta::FunctionDecl* t_fdecl) -> Any override;
+  auto visit(node::meta::Attribute* t_attr) -> Any override;
   auto visit(node::meta::LetDecl* t_ldecl) -> Any override;
   auto visit(node::meta::VarDecl* t_vdecl) -> Any override;
+  auto visit(node::meta::FunctionDecl* t_fdecl) -> Any override;
 
   // Operators:
   auto visit(node::operators::Arithmetic* t_arith) -> Any override;

--- a/src/crow/semantic/semantic_checker.hpp
+++ b/src/crow/semantic/semantic_checker.hpp
@@ -2,7 +2,7 @@
 #define CROW_CROW_SEMANTIC_SEMANTIC_CHECKER_HPP
 
 // STL Includes:
-#include <stack>
+#include <list>
 #include <string_view>
 
 // Absolute includes:
@@ -37,6 +37,7 @@ using node::NodeListPtr;
 using node::NodePtr;
 using node::node_traits::AttributeData;
 using node::node_traits::AttributeMetadata;
+using node::node_traits::AttributeSeq;
 using node::node_traits::TypeData;
 using symbol::SymbolData;
 using symbol::SymbolDataList;
@@ -44,7 +45,7 @@ using types::core::NativeType;
 using types::core::NativeTypeOpt;
 
 // Aliases:
-using AttributeContext = std::stack<AttributeMetadata>;
+using AttributeContext = std::list<AttributeData*>;
 
 // Classes:
 // TODO: Add check for checking if the AST only has a single module declaration.
@@ -84,9 +85,6 @@ class SemanticChecker : public NodeVisitor {
   auto annotate_type(TypeData* t_node, const SymbolData& t_data) -> void;
 
   // Attribute handling
-  auto is_attr_active() const -> bool;
-  auto current_attr() const -> const AttributeMetadata&;
-
   auto add_symbol_declaration(std::string_view t_id, const SymbolData& t_data)
     -> void;
 

--- a/src/crow/semantic/semantic_checker.hpp
+++ b/src/crow/semantic/semantic_checker.hpp
@@ -2,6 +2,7 @@
 #define CROW_CROW_SEMANTIC_SEMANTIC_CHECKER_HPP
 
 // STL Includes:
+#include <stack>
 #include <string_view>
 
 // Absolute includes:
@@ -24,19 +25,24 @@
  */
 
 namespace semantic {
-// Using Statements:
-using namespace ast;
+// Using:
+namespace node = ast::node;
 
-// Using Declarations:
-using ast::node::NodeListPtr;
-using ast::node::NodePtr;
 using ast::visitor::Any;
 using ast::visitor::NodeVisitor;
 using container::TextPosition;
+using node::NodeListPtr;
+using node::NodePtr;
+using node::node_traits::AttributeData;
+using node::node_traits::AttributeMetadata;
+using node::node_traits::TypeData;
 using symbol::SymbolData;
 using symbol::SymbolDataList;
 using types::core::NativeType;
 using types::core::NativeTypeOpt;
+
+// Aliases:
+using AttributeContext = std::stack<AttributeMetadata>;
 
 // Classes:
 // TODO: Add check for checking if the AST only has a single module declaration.
@@ -59,11 +65,25 @@ class SemanticChecker : public NodeVisitor {
   SymbolEnvState m_symbol_state;
   TypePromoter m_type_promoter;
 
+  AttributeContext m_attr_ctx;
+
   protected:
   // Environment related methods:
   auto push_env() -> void;
   auto pop_env() -> void;
   auto clear_env() -> void;
+
+  /*!
+	 */
+  auto annotate_attr(AttributeData* t_node) -> void;
+
+  /*!
+	 */
+  auto annotate_type(TypeData* t_node, const SymbolData& t_data) -> void;
+
+  // Attribute handling
+  auto is_attr_active() const -> bool;
+  auto current_attr() const -> const AttributeMetadata&;
 
   auto add_symbol_declaration(std::string_view t_id, const SymbolData& t_data)
     -> void;

--- a/src/crow/semantic/semantic_checker.hpp
+++ b/src/crow/semantic/semantic_checker.hpp
@@ -45,6 +45,7 @@ using types::core::NativeType;
 using types::core::NativeTypeOpt;
 
 // Aliases:
+//! Stores active contributes.
 using AttributeContext = AttributeSeq;
 
 // Classes:

--- a/src/crow/semantic/semantic_checker.hpp
+++ b/src/crow/semantic/semantic_checker.hpp
@@ -6,6 +6,8 @@
 #include <string_view>
 
 // Absolute includes:
+#include "crow/ast/node/node_traits/attribute_data.hpp"
+#include "crow/ast/node/node_traits/type_data.hpp"
 #include "crow/ast/visitor/node_visitor.hpp"
 #include "crow/container/text_position.hpp"
 #include "crow/types/semantic/semantic.hpp"
@@ -74,11 +76,11 @@ class SemanticChecker : public NodeVisitor {
   auto clear_env() -> void;
 
   /*!
-	 */
+   */
   auto annotate_attr(AttributeData* t_node) -> void;
 
   /*!
-	 */
+   */
   auto annotate_type(TypeData* t_node, const SymbolData& t_data) -> void;
 
   // Attribute handling

--- a/src/crow/settings/cli.cpp
+++ b/src/crow/settings/cli.cpp
@@ -96,8 +96,10 @@ auto add_nocolor_flag(CLI::App& t_app) -> void
 auto add_version_flag(CLI::App& t_app) -> void
 {
   // Version flag:
-  std::stringstream ss;
+  std::stringstream ss{};
+
   ss << "Version: " << CROW_PROJECT_VERSION;
+
   t_app.set_version_flag("-v,--version", ss.str(), "Show compiler version");
 }
 

--- a/src/crow/unit/translation_unit.cpp
+++ b/src/crow/unit/translation_unit.cpp
@@ -141,7 +141,8 @@ auto TranslationUnit::mir(NodePtr t_ast) -> ModulePtr
 
   // Check the semantics of the written program.
   MirBuilder builder{};
-  const auto module_ptr{builder.translate(t_ast)};
+  // const auto module_ptr{builder.translate(t_ast)};
+  ModulePtr module_ptr{};
 
   if(module_ptr) {
     DBG_INFO("CLIR Module: ", module_ptr->m_name);

--- a/src/crow/unit/translation_unit.cpp
+++ b/src/crow/unit/translation_unit.cpp
@@ -141,7 +141,8 @@ auto TranslationUnit::mir(NodePtr t_ast) -> ModulePtr
 
   // Check the semantics of the written program.
   MirBuilder builder{};
-  const auto module_ptr{builder.translate(t_ast)};
+  // const auto module_ptr{builder.translate(t_ast)};
+  const ModulePtr module_ptr{nullptr};
 
   if(module_ptr) {
     DBG_INFO("CLIR Module: ", module_ptr->m_name);

--- a/src/crow/unit/translation_unit.cpp
+++ b/src/crow/unit/translation_unit.cpp
@@ -141,8 +141,7 @@ auto TranslationUnit::mir(NodePtr t_ast) -> ModulePtr
 
   // Check the semantics of the written program.
   MirBuilder builder{};
-  // const auto module_ptr{builder.translate(t_ast)};
-  ModulePtr module_ptr{};
+  const auto module_ptr{builder.translate(t_ast)};
 
   if(module_ptr) {
     DBG_INFO("CLIR Module: ", module_ptr->m_name);

--- a/src/crow/unit/translation_unit.cpp
+++ b/src/crow/unit/translation_unit.cpp
@@ -141,8 +141,8 @@ auto TranslationUnit::mir(NodePtr t_ast) -> ModulePtr
 
   // Check the semantics of the written program.
   MirBuilder builder{};
-  // const auto module_ptr{builder.translate(t_ast)};
-  const ModulePtr module_ptr{nullptr};
+  const auto module_ptr{builder.translate(t_ast)};
+  // const ModulePtr module_ptr{nullptr};
 
   if(module_ptr) {
     DBG_INFO("CLIR Module: ", module_ptr->m_name);

--- a/src/lib/stdexcept/CMakeLists.txt
+++ b/src/lib/stdexcept/CMakeLists.txt
@@ -5,4 +5,5 @@ target_sources(${TARGET_CROW_LIB} PRIVATE
 	bad_any_cast.cpp
 	invalid_argument.cpp
 	runtime_error.cpp
+	logic_error.cpp
 )

--- a/src/lib/stdexcept/logic_error.cpp
+++ b/src/lib/stdexcept/logic_error.cpp
@@ -1,0 +1,6 @@
+#include "logic_error.hpp"
+
+namespace lib::stdexcept {
+LogicError::LogicError(const std::string_view t_msg): Exception{t_msg}
+{}
+} // namespace lib::stdexcept

--- a/src/lib/stdexcept/logic_error.hpp
+++ b/src/lib/stdexcept/logic_error.hpp
@@ -1,0 +1,27 @@
+#ifndef CROW_LIB_STDEXCEPT_LOGIC_ERROR_HPP
+#define CROW_LIB_STDEXCEPT_LOGIC_ERROR_HPP
+
+// Local Includes:
+#include "exception.hpp"
+
+// Macros:
+#define LOGIC_ERROR(...) lib::stdexcept::throw_logic_error(__VA_ARGS__)
+
+namespace lib::stdexcept {
+// Classes:
+class LogicError : public Exception {
+  public:
+  LogicError(std::string_view t_msg);
+
+  virtual ~LogicError() = default;
+};
+
+// Functions:
+template<typename... Args>
+inline auto throw_logic_error(Args&&... t_args) -> void
+{
+  throw_exception<LogicError>(std::forward<Args>(t_args)...);
+}
+} // namespace lib::stdexcept
+
+#endif // CROW_LIB_STDEXCEPT_LOGIC_ERROR_HPP

--- a/src/lib/stdexcept/runtime_error.hpp
+++ b/src/lib/stdexcept/runtime_error.hpp
@@ -4,7 +4,11 @@
 // Local Includes:
 #include "exception.hpp"
 
+// Macros:
+#define RUNTIME_ERROR(...) lib::stdexcept::throw_runtime_error(__VA_ARGS__)
+
 namespace lib::stdexcept {
+// Classes:
 class RuntimeError : public Exception {
   public:
   RuntimeError(std::string_view t_msg);

--- a/src/lib/stdexcept/stdexcept.hpp
+++ b/src/lib/stdexcept/stdexcept.hpp
@@ -5,6 +5,7 @@
 #include "bad_any_cast.hpp"
 #include "exception.hpp"
 #include "invalid_argument.hpp"
+#include "logic_error.hpp"
 #include "runtime_error.hpp"
 #include "unexpected_nullptr.hpp"
 

--- a/src/lib/stdprint.hpp
+++ b/src/lib/stdprint.hpp
@@ -102,7 +102,7 @@ inline auto print_weak_ptr(std::ostream& t_os, const std::weak_ptr<T>& t_wk_ptr)
 namespace vector {
 //! For printing vectors.
 template<typename T>
-auto operator<<(std::ostream& t_os, const std::vector<T>& t_vector)
+inline auto operator<<(std::ostream& t_os, const std::vector<T>& t_vector)
   -> std::ostream&
 {
   return detail::print_seq(t_os, t_vector);
@@ -112,7 +112,7 @@ auto operator<<(std::ostream& t_os, const std::vector<T>& t_vector)
 namespace array {
 //
 template<typename T, size_t S>
-auto operator<<(std::ostream& t_os, const std::array<T, S>& t_array)
+inline auto operator<<(std::ostream& t_os, const std::array<T, S>& t_array)
   -> std::ostream&
 {
   return detail::print_seq(t_os, t_array);
@@ -121,7 +121,8 @@ auto operator<<(std::ostream& t_os, const std::array<T, S>& t_array)
 
 namespace list {
 template<typename T>
-auto operator<<(std::ostream& t_os, const std::list<T>& t_list) -> std::ostream&
+inline auto operator<<(std::ostream& t_os, const std::list<T>& t_list)
+  -> std::ostream&
 {
   return detail::print_seq(t_os, t_list);
 }
@@ -129,21 +130,21 @@ auto operator<<(std::ostream& t_os, const std::list<T>& t_list) -> std::ostream&
 
 namespace smart_ptr {
 template<typename T>
-auto operator<<(std::ostream& t_os, const std::unique_ptr<T>& t_ptr)
+inline auto operator<<(std::ostream& t_os, const std::unique_ptr<T>& t_ptr)
   -> std::ostream&
 {
   return detail::print_smart_ptr(t_os, t_ptr);
 }
 
 template<typename T>
-auto operator<<(std::ostream& t_os, const std::shared_ptr<T>& t_ptr)
+inline auto operator<<(std::ostream& t_os, const std::shared_ptr<T>& t_ptr)
   -> std::ostream&
 {
   return detail::print_smart_ptr(t_os, t_ptr);
 }
 
 template<typename T>
-auto operator<<(std::ostream& t_os, const std::weak_ptr<T>& t_ptr)
+inline auto operator<<(std::ostream& t_os, const std::weak_ptr<T>& t_ptr)
   -> std::ostream&
 {
   return detail::print_smart_ptr(t_os, t_ptr);


### PR DESCRIPTION
Working on attribute using the `[[` and `]]` syntax like in C++.
Also adding `[[extern("C")]]` with a `{ }` body.
Only allow certain items, like globals, and functions.